### PR TITLE
Log dev server output to logs/dev.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
+# dev server logs (agent reads logs/dev.log)
+/logs
+
 # env files (can opt-in for committing if needed)
 .env*
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@9.15.4",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "mkdir -p logs && truncate -s 0 logs/dev.log && next dev --turbopack 2>&1 | tee logs/dev.log",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
Wraps the `dev` script so all Next.js output is teed to `logs/dev.log`, so the agent can read server output without attaching to the running process (matching the `crew` setup).

- `package.json` — `dev` now runs `mkdir -p logs && truncate -s 0 logs/dev.log && next dev --turbopack 2>&1 | tee logs/dev.log`. The `mkdir -p` keeps it working on fresh clones since `/logs` is gitignored.
- `.gitignore` — ignore `/logs`.

Verified locally: running `pnpm dev` creates `logs/dev.log` and captures startup output through the "Local: http://localhost:…" ready line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)