### PR TITLE
"Order again?" verdict on check-ins

### DIFF
--- a/drizzle/0002_normal_phantom_reporter.sql
+++ b/drizzle/0002_normal_phantom_reporter.sql
@@ -1,0 +1,11 @@
+CREATE TYPE "public"."verdict" AS ENUM('yes', 'maybe', 'no');--> statement-breakpoint
+-- Existing values are UTC wall-clock times (drizzle serialized Date.toISOString()).
+-- The explicit `USING ... AT TIME ZONE 'UTC'` makes the conversion deterministic
+-- regardless of the migrating session's TimeZone setting (hand-added to the
+-- drizzle-generated statements; snapshot is unchanged).
+ALTER TABLE "check_ins" ALTER COLUMN "visit_datetime" SET DATA TYPE timestamp with time zone USING "visit_datetime" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "check_ins" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "check_ins" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "check_ins" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "check_ins" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "check_ins" ADD COLUMN "verdict" "verdict";

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,363 @@
+{
+  "id": "c5ddac3e-8d05-4c9b-8570-0a9b25d8da8e",
+  "prevId": "2e6f25ee-7989-49b2-a61c-18365ea39cec",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": ["provider", "provider_account_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_name": {
+          "name": "place_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dish_text": {
+          "name": "dish_text",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_text": {
+          "name": "note_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visit_datetime": {
+          "name": "visit_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.verdict": {
+      "name": "verdict",
+      "schema": "public",
+      "values": ["yes", "maybe", "no"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1763344477242,
       "tag": "0001_lean_swordsman",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783891514851,
+      "tag": "0002_normal_phantom_reporter",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/checkins/[id]/route.test.ts
+++ b/src/app/api/checkins/[id]/route.test.ts
@@ -488,4 +488,225 @@ describe('PUT /api/checkins/[id]', () => {
       })
     );
   });
+
+  it('should let a legacy (null-verdict) check-in add a verdict', async () => {
+    (auth as Mock).mockResolvedValue({
+      user: { id: 'user-123', email: 'test@example.com' },
+      expires: '',
+    });
+
+    const legacyCheckIn = {
+      id: 'checkin-123',
+      userId: 'user-123',
+      placeId: 'place-abc',
+      placeName: 'Test Restaurant',
+      lat: 40.73,
+      lng: -73.99,
+      dishText: 'Pizza',
+      noteText: null,
+      verdict: null,
+      visitDatetime: new Date('2025-01-15'),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const mockSelect = {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([legacyCheckIn]),
+        }),
+      }),
+    };
+    (db.select as Mock).mockReturnValue(mockSelect);
+
+    const mockUpdate = {
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ ...legacyCheckIn, verdict: 'yes' }]),
+        }),
+      }),
+    };
+    (db.update as Mock).mockReturnValue(mockUpdate);
+
+    const request = new NextRequest('http://localhost/api/checkins/123', {
+      method: 'PUT',
+      body: JSON.stringify({
+        placeId: 'place-abc',
+        placeName: 'Test Restaurant',
+        lat: 40.73,
+        lng: -73.99,
+        dishText: 'Pizza',
+        verdict: 'yes',
+      }),
+    });
+
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: 'checkin-123' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.verdict).toBe('yes');
+    expect(mockUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({ verdict: 'yes' })
+    );
+  });
+
+  it('should preserve the existing verdict when none is supplied', async () => {
+    (auth as Mock).mockResolvedValue({
+      user: { id: 'user-123', email: 'test@example.com' },
+      expires: '',
+    });
+
+    const existingCheckIn = {
+      id: 'checkin-123',
+      userId: 'user-123',
+      placeId: 'place-abc',
+      placeName: 'Test Restaurant',
+      lat: 40.73,
+      lng: -73.99,
+      dishText: 'Pizza',
+      noteText: null,
+      verdict: 'yes',
+      visitDatetime: new Date('2025-01-15'),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const mockSelect = {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([existingCheckIn]),
+        }),
+      }),
+    };
+    (db.select as Mock).mockReturnValue(mockSelect);
+
+    const mockUpdate = {
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([existingCheckIn]),
+        }),
+      }),
+    };
+    (db.update as Mock).mockReturnValue(mockUpdate);
+
+    const request = new NextRequest('http://localhost/api/checkins/123', {
+      method: 'PUT',
+      body: JSON.stringify({
+        placeId: 'place-abc',
+        placeName: 'Test Restaurant',
+        lat: 40.73,
+        lng: -73.99,
+        dishText: 'Pizza',
+        // verdict omitted entirely
+      }),
+    });
+
+    await PUT(request, { params: Promise.resolve({ id: 'checkin-123' }) });
+
+    expect(mockUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({ verdict: 'yes' })
+    );
+  });
+
+  it('should not clear an existing verdict when null is supplied', async () => {
+    (auth as Mock).mockResolvedValue({
+      user: { id: 'user-123', email: 'test@example.com' },
+      expires: '',
+    });
+
+    const existingCheckIn = {
+      id: 'checkin-123',
+      userId: 'user-123',
+      placeId: 'place-abc',
+      placeName: 'Test Restaurant',
+      lat: 40.73,
+      lng: -73.99,
+      dishText: 'Pizza',
+      noteText: null,
+      verdict: 'no',
+      visitDatetime: new Date('2025-01-15'),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const mockSelect = {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([existingCheckIn]),
+        }),
+      }),
+    };
+    (db.select as Mock).mockReturnValue(mockSelect);
+
+    const mockUpdate = {
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([existingCheckIn]),
+        }),
+      }),
+    };
+    (db.update as Mock).mockReturnValue(mockUpdate);
+
+    const request = new NextRequest('http://localhost/api/checkins/123', {
+      method: 'PUT',
+      body: JSON.stringify({
+        placeId: 'place-abc',
+        placeName: 'Test Restaurant',
+        lat: 40.73,
+        lng: -73.99,
+        dishText: 'Pizza',
+        verdict: null,
+      }),
+    });
+
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: 'checkin-123' }),
+    });
+
+    expect(response.status).toBe(200);
+    // null must not strip the existing verdict.
+    expect(mockUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({ verdict: 'no' })
+    );
+  });
+
+  it('should reject an invalid verdict value', async () => {
+    (auth as Mock).mockResolvedValue({
+      user: { id: 'user-123', email: 'test@example.com' },
+      expires: '',
+    });
+
+    const mockSelect = {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'checkin-123' }]),
+        }),
+      }),
+    };
+    (db.select as Mock).mockReturnValue(mockSelect);
+
+    const request = new NextRequest('http://localhost/api/checkins/123', {
+      method: 'PUT',
+      body: JSON.stringify({
+        placeId: 'place-abc',
+        placeName: 'Test Restaurant',
+        lat: 40.73,
+        lng: -73.99,
+        dishText: 'Pizza',
+        verdict: 'sometimes',
+      }),
+    });
+
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: 'checkin-123' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain('verdict');
+  });
 });

--- a/src/app/api/checkins/[id]/route.ts
+++ b/src/app/api/checkins/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { db } from '@/lib/db/client';
 import { checkIns } from '@/lib/db/schema';
+import { VERDICTS, isVerdict } from '@/lib/verdict';
 import { eq, and } from 'drizzle-orm';
 
 export async function DELETE(
@@ -62,8 +63,16 @@ export async function PUT(
   try {
     const { id } = await params;
     const body = await request.json();
-    const { placeId, placeName, lat, lng, dishText, noteText, visitDatetime } =
-      body;
+    const {
+      placeId,
+      placeName,
+      lat,
+      lng,
+      dishText,
+      noteText,
+      verdict,
+      visitDatetime,
+    } = body;
 
     // Check if check-in exists and belongs to user
     const existing = await db
@@ -137,6 +146,18 @@ export async function PUT(
       }
     }
 
+    // Verdict is optional on edit: legacy rows can add one, but you aren't
+    // forced to. A missing (undefined) or null verdict preserves the existing
+    // value — the product has no "clear my verdict" affordance, so we never let
+    // a null strip a verdict that's already there. Any other non-verdict value
+    // is a client error.
+    if (verdict !== undefined && verdict !== null && !isVerdict(verdict)) {
+      return NextResponse.json(
+        { error: `verdict must be one of: ${VERDICTS.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
     const visitDate = visitDatetime ? new Date(visitDatetime) : new Date();
     if (isNaN(visitDate.getTime())) {
       return NextResponse.json(
@@ -155,6 +176,9 @@ export async function PUT(
         lng,
         dishText,
         noteText: noteText || null,
+        // Preserve the existing verdict unless a valid new one is supplied
+        // (null/undefined never clears it).
+        verdict: isVerdict(verdict) ? verdict : existing[0].verdict,
         visitDatetime: visitDate,
         updatedAt: new Date(),
       })

--- a/src/app/api/checkins/route.test.ts
+++ b/src/app/api/checkins/route.test.ts
@@ -185,6 +185,7 @@ describe('POST /api/checkins', () => {
         lng: -73.99,
         dishText: 'Margherita Pizza',
         noteText: 'Amazing crust',
+        verdict: 'yes',
         visitDatetime: '2025-01-15T18:00:00Z',
       }),
     });
@@ -195,6 +196,56 @@ describe('POST /api/checkins', () => {
     expect(response.status).toBe(201);
     expect(data.id).toBe('checkin-123');
     expect(data.dishText).toBe('Margherita Pizza');
+  });
+
+  it('should require a verdict', async () => {
+    (auth as Mock).mockResolvedValue({
+      user: { id: 'user-123', email: 'test@example.com' },
+      expires: '',
+    });
+
+    const request = new NextRequest('http://localhost/api/checkins', {
+      method: 'POST',
+      body: JSON.stringify({
+        placeId: 'place-abc',
+        placeName: 'Test Restaurant',
+        lat: 40.73,
+        lng: -73.99,
+        dishText: 'Pizza',
+        // verdict omitted
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain('verdict');
+  });
+
+  it('should reject an invalid verdict value', async () => {
+    (auth as Mock).mockResolvedValue({
+      user: { id: 'user-123', email: 'test@example.com' },
+      expires: '',
+    });
+
+    const request = new NextRequest('http://localhost/api/checkins', {
+      method: 'POST',
+      body: JSON.stringify({
+        placeId: 'place-abc',
+        placeName: 'Test Restaurant',
+        lat: 40.73,
+        lng: -73.99,
+        dishText: 'Pizza',
+        verdict: 'sometimes',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain('verdict');
   });
 
   it('should require placeId', async () => {
@@ -328,6 +379,7 @@ describe('POST /api/checkins', () => {
         lat: 40.73,
         lng: -73.99,
         dishText: 'Pizza',
+        verdict: 'maybe',
         // noteText omitted
       }),
     });

--- a/src/app/api/checkins/route.ts
+++ b/src/app/api/checkins/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { db } from '@/lib/db/client';
 import { checkIns } from '@/lib/db/schema';
+import { VERDICTS, isVerdict } from '@/lib/verdict';
 import { eq, desc } from 'drizzle-orm';
 
 export async function GET() {
@@ -40,8 +41,16 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { placeId, placeName, lat, lng, dishText, noteText, visitDatetime } =
-      body;
+    const {
+      placeId,
+      placeName,
+      lat,
+      lng,
+      dishText,
+      noteText,
+      verdict,
+      visitDatetime,
+    } = body;
 
     if (!placeId || typeof placeId !== 'string') {
       return NextResponse.json(
@@ -100,6 +109,16 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Verdict is required on new check-ins going forward (legacy rows are null).
+    if (!isVerdict(verdict)) {
+      return NextResponse.json(
+        {
+          error: `verdict is required and must be one of: ${VERDICTS.join(', ')}`,
+        },
+        { status: 400 }
+      );
+    }
+
     const visitDate = visitDatetime ? new Date(visitDatetime) : new Date();
     if (isNaN(visitDate.getTime())) {
       return NextResponse.json(
@@ -118,6 +137,7 @@ export async function POST(request: NextRequest) {
         lng,
         dishText,
         noteText: noteText || null,
+        verdict,
         visitDatetime: visitDate,
       })
       .returning();

--- a/src/app/check-in/page.test.tsx
+++ b/src/app/check-in/page.test.tsx
@@ -71,7 +71,7 @@ describe('CheckInPage', () => {
       expect(submitButton).toBeDisabled();
     });
 
-    it('should enable submit button when place and dish are provided', async () => {
+    it('should enable submit button when place, dish, and verdict are provided', async () => {
       const user = userEvent.setup();
       render(<CheckInPage />);
 
@@ -83,9 +83,34 @@ describe('CheckInPage', () => {
       const dishInput = screen.getByPlaceholderText(/margherita pizza/i);
       await user.type(dishInput, 'Test Dish');
 
+      // Choose a verdict
+      await user.click(screen.getByRole('radio', { name: /order again/i }));
+
       const submitButton = screen.getByRole('button', {
         name: /save check-in/i,
       });
+
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    it('should keep submit disabled until a verdict is chosen', async () => {
+      const user = userEvent.setup();
+      render(<CheckInPage />);
+
+      await user.click(screen.getByText('Select Test Place'));
+      await user.type(
+        screen.getByPlaceholderText(/margherita pizza/i),
+        'Test Dish'
+      );
+
+      const submitButton = screen.getByRole('button', {
+        name: /save check-in/i,
+      });
+
+      // Place + dish present, but no verdict yet
+      expect(submitButton).toBeDisabled();
+
+      await user.click(screen.getByRole('radio', { name: /order again/i }));
 
       expect(submitButton).not.toBeDisabled();
     });
@@ -199,6 +224,9 @@ describe('CheckInPage', () => {
       const noteInput = screen.getByPlaceholderText(/what did you think/i);
       await user.type(noteInput, 'Great food!');
 
+      // Choose a verdict
+      await user.click(screen.getByRole('radio', { name: /order again/i }));
+
       // Submit
       const submitButton = screen.getByRole('button', {
         name: /save check-in/i,
@@ -229,6 +257,7 @@ describe('CheckInPage', () => {
         lng: -73.99,
         dishText: 'Test Dish',
         noteText: 'Great food!',
+        verdict: 'yes',
       });
 
       // Should redirect to history
@@ -254,6 +283,9 @@ describe('CheckInPage', () => {
       // Enter dish text
       const dishInput = screen.getByPlaceholderText(/margherita pizza/i);
       await user.type(dishInput, 'Test Dish');
+
+      // Choose a verdict
+      await user.click(screen.getByRole('radio', { name: /order again/i }));
 
       // Submit
       const submitButton = screen.getByRole('button', {
@@ -283,6 +315,9 @@ describe('CheckInPage', () => {
       // Enter dish text
       const dishInput = screen.getByPlaceholderText(/margherita pizza/i);
       await user.type(dishInput, 'Test Dish');
+
+      // Choose a verdict
+      await user.click(screen.getByRole('radio', { name: /order again/i }));
 
       // Submit
       const submitButton = screen.getByRole('button', {
@@ -319,6 +354,7 @@ describe('CheckInPage', () => {
         screen.getByPlaceholderText(/what did you think/i),
         'Great!'
       );
+      await user.click(screen.getByRole('radio', { name: /order again/i }));
 
       // Submit
       await user.click(screen.getByRole('button', { name: /save check-in/i }));

--- a/src/app/check-in/page.tsx
+++ b/src/app/check-in/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { PlacePicker } from '@/components/place-picker';
+import { VerdictControl } from '@/components/verdict-control';
+import type { Verdict } from '@/lib/verdict';
 import type { Place } from '@/lib/places';
 
 export default function CheckInPage() {
@@ -10,6 +12,7 @@ export default function CheckInPage() {
   const [selectedPlace, setSelectedPlace] = useState<Place | null>(null);
   const [dishText, setDishText] = useState('');
   const [noteText, setNoteText] = useState('');
+  const [verdict, setVerdict] = useState<Verdict | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,6 +27,11 @@ export default function CheckInPage() {
 
     if (!dishText.trim()) {
       setError('Please enter a dish name');
+      return;
+    }
+
+    if (!verdict) {
+      setError('Please choose whether you’d order this again');
       return;
     }
 
@@ -42,6 +50,7 @@ export default function CheckInPage() {
           lng: selectedPlace.lng,
           dishText: dishText.trim(),
           noteText: noteText.trim() || null,
+          verdict,
           visitDatetime: new Date().toISOString(),
         }),
       });
@@ -104,6 +113,18 @@ export default function CheckInPage() {
             </div>
           </div>
 
+          {/* Verdict — the most important input on the form */}
+          <div>
+            <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Would you order this again? *
+            </span>
+            <VerdictControl
+              value={verdict}
+              onChange={setVerdict}
+              ariaLabel="Would you order this again?"
+            />
+          </div>
+
           {/* Note Text */}
           <div>
             <label
@@ -136,7 +157,7 @@ export default function CheckInPage() {
           {/* Submit Button */}
           <button
             type="submit"
-            disabled={loading || !selectedPlace || !dishText.trim()}
+            disabled={loading || !selectedPlace || !dishText.trim() || !verdict}
             className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white font-medium py-3 px-4 rounded-lg transition-colors"
           >
             {loading ? 'Saving...' : 'Save Check-In'}

--- a/src/app/history/page.test.tsx
+++ b/src/app/history/page.test.tsx
@@ -64,6 +64,7 @@ describe('HistoryPage', () => {
         lng: -73.99,
         dishText: 'Margherita Pizza',
         noteText: 'Amazing crust!',
+        verdict: 'yes',
         visitDatetime: '2025-01-15T18:00:00Z',
         createdAt: '2025-01-15T18:00:00Z',
         updatedAt: '2025-01-15T18:00:00Z',
@@ -76,6 +77,7 @@ describe('HistoryPage', () => {
         lng: -73.98,
         dishText: 'Caesar Salad',
         noteText: null,
+        verdict: null, // legacy row, no verdict
         visitDatetime: '2025-01-14T12:00:00Z',
         createdAt: '2025-01-14T12:00:00Z',
         updatedAt: '2025-01-14T12:00:00Z',
@@ -97,6 +99,10 @@ describe('HistoryPage', () => {
       expect(screen.getByText('Caesar Salad')).toBeInTheDocument();
       expect(screen.getByText('Another Place')).toBeInTheDocument();
       expect(screen.queryByText('No notes')).not.toBeInTheDocument();
+
+      // The rated check-in shows a verdict badge; the legacy null-verdict one
+      // shows nothing. "Order again" is unique to the yes verdict.
+      expect(screen.getByText(/order again/i)).toBeInTheDocument();
     });
   });
 

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { VerdictControl } from '@/components/verdict-control';
+import { VerdictBadge } from '@/components/verdict-badge';
+import type { Verdict } from '@/lib/verdict';
 
 interface CheckIn {
   id: string;
@@ -10,6 +13,7 @@ interface CheckIn {
   lng: number;
   dishText: string;
   noteText: string | null;
+  verdict: Verdict | null;
   visitDatetime: string;
   createdAt: string;
   updatedAt: string;
@@ -22,6 +26,7 @@ export default function HistoryPage() {
   const [editingCheckIn, setEditingCheckIn] = useState<CheckIn | null>(null);
   const [editDishText, setEditDishText] = useState('');
   const [editNoteText, setEditNoteText] = useState('');
+  const [editVerdict, setEditVerdict] = useState<Verdict | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
 
@@ -87,12 +92,14 @@ export default function HistoryPage() {
     setEditingCheckIn(checkIn);
     setEditDishText(checkIn.dishText);
     setEditNoteText(checkIn.noteText || '');
+    setEditVerdict(checkIn.verdict);
   };
 
   const handleCancelEdit = () => {
     setEditingCheckIn(null);
     setEditDishText('');
     setEditNoteText('');
+    setEditVerdict(null);
   };
 
   const handleSaveEdit = async () => {
@@ -112,6 +119,7 @@ export default function HistoryPage() {
           lng: editingCheckIn.lng,
           dishText: editDishText.trim(),
           noteText: editNoteText.trim() || null,
+          verdict: editVerdict,
           visitDatetime: editingCheckIn.visitDatetime,
         }),
       });
@@ -205,9 +213,14 @@ export default function HistoryPage() {
               >
                 <div className="flex justify-between items-start mb-3">
                   <div>
-                    <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-                      {checkIn.dishText}
-                    </h2>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                        {checkIn.dishText}
+                      </h2>
+                      {checkIn.verdict && (
+                        <VerdictBadge verdict={checkIn.verdict} />
+                      )}
+                    </div>
                     <p className="text-gray-600 dark:text-gray-400 mt-1">
                       {checkIn.placeName}
                     </p>
@@ -283,6 +296,17 @@ export default function HistoryPage() {
                   <div className="mt-1 text-sm text-gray-500 dark:text-gray-400 text-right">
                     {100 - editDishText.length} characters remaining
                   </div>
+                </div>
+
+                {/* Verdict */}
+                <div>
+                  <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    Would you order this again?
+                  </span>
+                  <VerdictControl
+                    value={editVerdict}
+                    onChange={setEditVerdict}
+                  />
                 </div>
 
                 {/* Note Text */}

--- a/src/components/verdict-badge.tsx
+++ b/src/components/verdict-badge.tsx
@@ -1,0 +1,18 @@
+import { verdictStyles, type Verdict } from '@/lib/verdict';
+
+interface VerdictBadgeProps {
+  verdict: Verdict;
+}
+
+/** Compact colored pill showing a check-in's verdict in history / place pages. */
+export function VerdictBadge({ verdict }: VerdictBadgeProps) {
+  const style = verdictStyles[verdict];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${style.badge}`}
+    >
+      <span className="font-semibold">{style.label}</span>
+      <span className="opacity-80">· {style.meaning}</span>
+    </span>
+  );
+}

--- a/src/components/verdict-control.tsx
+++ b/src/components/verdict-control.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useRef } from 'react';
+import { VERDICTS, verdictStyles, type Verdict } from '@/lib/verdict';
+
+interface VerdictControlProps {
+  value: Verdict | null;
+  onChange: (verdict: Verdict) => void;
+  /** Accessible label for the radiogroup. */
+  ariaLabel?: string;
+}
+
+/**
+ * The most important input on the check-in form: "Would you order this again?"
+ * A required, three-option segmented control, color-coded green/amber/red.
+ *
+ * Implements the ARIA radiogroup pattern: roving tabindex (one tab stop) and
+ * arrow-key navigation that moves focus and selects, per WAI-ARIA.
+ */
+export function VerdictControl({
+  value,
+  onChange,
+  ariaLabel = 'Would you order this again?',
+}: VerdictControlProps) {
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleKeyDown = (event: React.KeyboardEvent, index: number) => {
+    let nextIndex: number | null = null;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      nextIndex = (index + 1) % VERDICTS.length;
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      nextIndex = (index - 1 + VERDICTS.length) % VERDICTS.length;
+    }
+    if (nextIndex === null) return;
+    event.preventDefault();
+    onChange(VERDICTS[nextIndex]);
+    buttonRefs.current[nextIndex]?.focus();
+  };
+
+  // Roving tabindex: the selected option is the single tab stop; if none is
+  // selected yet, the first option holds it.
+  const tabStopIndex = value ? VERDICTS.indexOf(value) : 0;
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="grid grid-cols-3 gap-2"
+    >
+      {VERDICTS.map((verdict, index) => {
+        const style = verdictStyles[verdict];
+        const isSelected = value === verdict;
+        return (
+          <button
+            key={verdict}
+            ref={el => {
+              buttonRefs.current[index] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            tabIndex={index === tabStopIndex ? 0 : -1}
+            onClick={() => onChange(verdict)}
+            onKeyDown={e => handleKeyDown(e, index)}
+            className={`flex flex-col items-center justify-center rounded-lg border py-3 px-2 text-center transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-offset-gray-900 ${
+              isSelected
+                ? style.selected
+                : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
+            <span className="text-lg font-semibold">{style.label}</span>
+            <span
+              className={`text-xs ${isSelected ? 'text-white/90' : 'text-gray-500 dark:text-gray-400'}`}
+            >
+              {style.meaning}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,5 +1,6 @@
 import {
   pgTable,
+  pgEnum,
   text,
   timestamp,
   integer,
@@ -7,6 +8,12 @@ import {
   doublePrecision,
   varchar,
 } from 'drizzle-orm/pg-core';
+import { VERDICTS } from '@/lib/verdict';
+
+// "Would you order this again?" — the heart of the product (S2).
+// Nullable on the table: historic rows predate the verdict; the form
+// requires it going forward. Values come from the DB-free source of truth.
+export const verdictEnum = pgEnum('verdict', VERDICTS);
 
 export const users = pgTable('users', {
   id: text('id')
@@ -76,7 +83,15 @@ export const checkIns = pgTable('check_ins', {
   lng: doublePrecision('lng').notNull(),
   dishText: varchar('dish_text', { length: 100 }).notNull(),
   noteText: varchar('note_text', { length: 500 }),
-  visitDatetime: timestamp('visit_datetime', { mode: 'date' }).notNull(),
-  createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { mode: 'date' }).defaultNow().notNull(),
+  verdict: verdictEnum('verdict'),
+  visitDatetime: timestamp('visit_datetime', {
+    mode: 'date',
+    withTimezone: true,
+  }).notNull(),
+  createdAt: timestamp('created_at', { mode: 'date', withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { mode: 'date', withTimezone: true })
+    .defaultNow()
+    .notNull(),
 });

--- a/src/lib/verdict.ts
+++ b/src/lib/verdict.ts
@@ -1,0 +1,47 @@
+// Single source of truth for verdict values, kept free of DB imports so it can
+// be used from client components without pulling Drizzle into the bundle.
+// The Drizzle enum (src/lib/db/schema.ts) is derived from this.
+export const VERDICTS = ['yes', 'maybe', 'no'] as const;
+
+export type Verdict = (typeof VERDICTS)[number];
+
+export function isVerdict(value: unknown): value is Verdict {
+  return (
+    typeof value === 'string' && (VERDICTS as readonly string[]).includes(value)
+  );
+}
+
+interface VerdictStyle {
+  /** Short label used on the segmented control and badge. */
+  label: string;
+  /** Sentence-shaped meaning shown alongside the badge. */
+  meaning: string;
+  /** Classes for the badge pill. */
+  badge: string;
+  /** Classes for the segmented control button when selected. */
+  selected: string;
+}
+
+// Green / amber / red — the verdict is decision-shaped on purpose (S2).
+export const verdictStyles: Record<Verdict, VerdictStyle> = {
+  yes: {
+    label: 'Yes',
+    meaning: 'Order again',
+    badge:
+      'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    selected: 'bg-green-600 text-white border-green-600 shadow-sm',
+  },
+  maybe: {
+    label: 'Maybe',
+    meaning: 'On the fence',
+    badge:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    selected: 'bg-amber-500 text-white border-amber-500 shadow-sm',
+  },
+  no: {
+    label: 'No',
+    meaning: "Wouldn't reorder",
+    badge: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+    selected: 'bg-red-600 text-white border-red-600 shadow-sm',
+  },
+};


### PR DESCRIPTION
## S2 · "Order again?" verdict

Every check-in now records a **Yes / Maybe / No** verdict answering *"Would you order this again?"* — chosen at check-in, editable later, shown in history. This is the heart of the product; it's decision-shaped on purpose (not stars) and later powers "% would order again" rankings.

### Schema + migration (`0002`)
- `verdict` pgEnum (`yes` | `maybe` | `no`), **nullable** on `check_ins` — legacy rows stay null; the form requires it going forward.
- Enum values live in a **DB-free source of truth** (`src/lib/verdict.ts`); the Drizzle enum derives from it, so client components don't pull the schema module into the browser bundle.
- Also converts `visit_datetime` / `created_at` / `updated_at` to **`timestamptz`** while the table is small (per the backlog), with an explicit `USING ... AT TIME ZONE 'UTC'` so the conversion is deterministic regardless of the migrating session's timezone.

### API
- **POST** requires a valid verdict → 400 on missing/invalid.
- **PUT** verdict is optional: a valid value sets it (this is how a legacy null-verdict row gets one added), but **null/undefined preserves the existing verdict** — a verdict is never silently cleared (there's no "clear verdict" affordance in the product).

### UI
- Large, required, color-coded **segmented control** (green/amber/red) on the check-in form and edit modal, implementing the ARIA **radiogroup** pattern — roving tabindex + arrow-key navigation.
- Verdict **badge** on each history card (legacy null-verdict rows show nothing).

### Tests
104 pass. New coverage: POST verdict required + invalid rejected; PUT add-to-legacy, invalid rejected, omit-preserves, null-does-not-clear; form submit-gating on verdict; history badge rendering.

### Review
Ran the `reviewer` subagent adversarially; its findings on PUT null-clearing, migration timezone determinism, ARIA radiogroup conformance, dead-code dedupe, and client-bundle coupling are all addressed in this PR.

### ⚠️ Manual step
Run `pnpm db:migrate` against the Neon branch to apply migration `0002` before this is functional in a live environment. (Local gates — tsc, lint, format, 104 tests, build — are all green; the app itself wasn't driven against a live DB from here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)