### PR TITLE
Run database migrations on production deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,24 @@ Brand: **The Usual**. "Fivesquare" remains the in-house project/repo codename.
 
 ## Development
 
-This project follows the MVP roadmap outlined in `Todo.md`. See `PRD.md` for detailed product requirements.
+This project follows the roadmap in `BACKLOG.md` — one story per PR, shipped in order.
+
+## Deployment
+
+Hosted on **Vercel** (project `fivesquareapp`), backed by **Neon** Postgres. Deploys are driven by the Vercel GitHub integration:
+
+- **Open a PR** → preview deployment.
+- **Merge to `main`** → production deployment.
+
+**Database migrations run automatically on production deploys.** The `vercel-build` script runs `scripts/migrate-on-deploy.mjs` (which applies pending Drizzle migrations via `drizzle-kit migrate`) before `next build`. Migrations only run when `VERCEL_ENV=production`; preview and local builds skip them, so a preview never mutates the production database.
+
+Because migrations run inside the production build, keep them **backward-compatible** (expand-only: add nullable columns, widen types) so the currently-live version keeps working while the new build is created and promoted. Destructive changes (dropping a column) should be split across two deploys.
+
+To apply migrations manually against any database:
+
+```bash
+DATABASE_URL="<connection-string>" pnpm exec drizzle-kit migrate
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "mkdir -p logs && truncate -s 0 logs/dev.log && next dev --turbopack 2>&1 | tee logs/dev.log",
     "build": "next build",
+    "vercel-build": "node scripts/migrate-on-deploy.mjs && next build",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",

--- a/scripts/migrate-on-deploy.mjs
+++ b/scripts/migrate-on-deploy.mjs
@@ -1,0 +1,33 @@
+// Applies pending Drizzle migrations as part of a Vercel *production* deploy,
+// so schema changes ship atomically with the code that needs them instead of
+// requiring a manual `pnpm db:migrate`. Wired into the `vercel-build` script.
+//
+// Only production runs migrations. Preview/development builds skip — they must
+// never mutate the production database. (Once previews get their own Neon
+// branch, this gate can be relaxed to migrate previews too.)
+//
+// Our migrations are expand-only/backward-compatible, so running them before
+// the new code serves traffic is safe even for the currently-live version.
+import { execSync } from 'node:child_process';
+
+const vercelEnv = process.env.VERCEL_ENV ?? 'local';
+
+if (vercelEnv !== 'production') {
+  console.log(
+    `[migrate-on-deploy] VERCEL_ENV=${vercelEnv}; skipping migrations (production only).`
+  );
+  process.exit(0);
+}
+
+if (!process.env.DATABASE_URL) {
+  console.error(
+    '[migrate-on-deploy] DATABASE_URL is not set; refusing to build without it.'
+  );
+  process.exit(1);
+}
+
+console.log('[migrate-on-deploy] Applying pending migrations…');
+// Fails the build (and thus the deploy) if a migration errors, so broken
+// schema never reaches production alongside the new code.
+execSync('pnpm exec drizzle-kit migrate', { stdio: 'inherit' });
+console.log('[migrate-on-deploy] Migrations up to date.');


### PR DESCRIPTION
## Problem

Deploys don't run migrations. Merging a schema-changing story (e.g. S2's `verdict` column) deploys code that expects columns the live Neon DB doesn't have yet — breaking production until someone manually runs `pnpm db:migrate`.

## Fix

Add a `vercel-build` script so Vercel runs pending Drizzle migrations before building:

```
"vercel-build": "node scripts/migrate-on-deploy.mjs && next build"
```

`scripts/migrate-on-deploy.mjs`:
- Runs `drizzle-kit migrate` **only when `VERCEL_ENV=production`**. Preview and local builds skip, so a preview deploy never mutates the production database.
- Fails the build (and thus the deploy) if a migration errors — broken schema never ships alongside new code.
- Refuses to proceed if `DATABASE_URL` is unset in production.

Verified the gating locally: skips on `local`/`preview`, errors on `production` without `DATABASE_URL`.

## Operational note

Migrations run inside the production build while the previous version is still serving, so keep them **backward-compatible** (expand-only: nullable columns, type widening). Destructive changes get split across two deploys. Documented in the README's new Deployment section.

## ⚠️ One thing to verify before merging

This only takes effect if the Vercel project's **Build Command is left at the default** (unset). If the dashboard has an explicit `next build` / `pnpm build` override, it wins over `vercel-build` and migrations won't run — clear the override so it uses the package.json script. (CI is unaffected: it runs `pnpm build`, not `vercel-build`.)

## Merge order

Per our plan: apply the outstanding migration(s) manually first, then merge this. After it lands, future schema PRs migrate themselves on the production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)