### PR TITLE
chore: exclude AGENTS.md from prettier / lint-staged

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,7 @@ dist/
 
 # Public assets
 public/
+
+# Doctrine doc — hand-maintained (synced from global agent doctrine); keep
+# prettier (and thus the lint-staged pre-commit hook + CI format:check) off it.
+AGENTS.md


### PR DESCRIPTION
`AGENTS.md` is a hand-maintained doctrine doc (synced from the global agent doctrine). Its formatting isn't prettier's to own, and it was intermittently getting rewritten when caught by the lint-staged `prettier --write` on `*.md`.

Adding it to `.prettierignore` keeps **both** the lint-staged pre-commit hook and CI's `format:check` off it — prettier respects `.prettierignore` even for explicitly-passed files (verified: `prettier --write AGENTS.md` is a no-op, exit 0).

Note: the actual blank-line stripping I kept seeing on the file isn't done by any repo tooling (no prettier/eslint/markdownlint/git-filter touches it that way) — it appears to come from the environment (editor or dotfiles sync). This change stops that churn from ever failing CI or riding in via the format hook, but the external rewriter is worth tracking down separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)