### PR TITLE
S5: Dish rollup on place pages (+ retire denormalized place columns, phase 1)

### DIFF
--- a/drizzle/0004_lonely_supernaut.sql
+++ b/drizzle/0004_lonely_supernaut.sql
@@ -1,0 +1,23 @@
+-- Re-link (S5): S4's backfill (0003) ran once, so any check-in written by old
+-- code during the S4 deploy window landed with place_uuid = NULL. S5 code reads
+-- place data via the place_uuid join and stops touching the denormalized columns
+-- below, so those orphans would render place-less. Re-run the 0003 backfill
+-- block here — using the denormalized columns while they still exist — so every
+-- row is linked before S5 serves and before S5b drops the columns. Idempotent
+-- (ON CONFLICT DO NOTHING + WHERE place_uuid IS NULL); a no-op when there are no
+-- orphans, which is the normal case.
+INSERT INTO "places" ("id", "google_place_id", "name", "lat", "lng", "created_at", "updated_at")
+SELECT DISTINCT ON ("place_id")
+  gen_random_uuid()::text, "place_id", "place_name", "lat", "lng", now(), now()
+FROM "check_ins"
+WHERE "place_uuid" IS NULL AND "place_id" IS NOT NULL
+ORDER BY "place_id", "visit_datetime" DESC, "id" DESC
+ON CONFLICT ("google_place_id") DO NOTHING;--> statement-breakpoint
+UPDATE "check_ins" AS "c"
+SET "place_uuid" = "p"."id"
+FROM "places" AS "p"
+WHERE "p"."google_place_id" = "c"."place_id" AND "c"."place_uuid" IS NULL;--> statement-breakpoint
+ALTER TABLE "check_ins" ALTER COLUMN "place_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "check_ins" ALTER COLUMN "place_name" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "check_ins" ALTER COLUMN "lat" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "check_ins" ALTER COLUMN "lng" DROP NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,453 @@
+{
+  "id": "8739347f-714b-407c-9537-fcdc77fdd8a7",
+  "prevId": "2ce3089d-14f5-4830-a68e-4d52be73dc99",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": ["provider", "provider_account_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_uuid": {
+          "name": "place_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_name": {
+          "name": "place_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dish_text": {
+          "name": "dish_text",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_text": {
+          "name": "note_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visit_datetime": {
+          "name": "visit_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "check_ins_place_uuid_places_id_fk": {
+          "name": "check_ins_place_uuid_places_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "places",
+          "columnsFrom": ["place_uuid"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["google_place_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.verdict": {
+      "name": "verdict",
+      "schema": "public",
+      "values": ["yes", "maybe", "no"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783902643974,
       "tag": "0003_familiar_sunfire",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1783905182792,
+      "tag": "0004_lonely_supernaut",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -79,15 +79,17 @@ async function main() {
   for (let i = 0; i < CHECK_INS.length; i++) {
     const [placeIdx, dish, verdict, note, daysAgo] = CHECK_INS[i];
     const place = PLACES[placeIdx];
-    const [placeId, placeName, , , lat, lng] = place;
+    const placeId = place[0]; // seed place id doubles as its google_place_id
     const visitDatetime = new Date(now - daysAgo * DAY_MS).toISOString();
 
+    // Reference the place via place_uuid only — the denormalized place columns
+    // are deprecated (dropped at S5b), so don't write them.
     await sql`
       INSERT INTO check_ins
-        (id, user_id, place_uuid, place_id, place_name, lat, lng, dish_text, note_text, verdict, visit_datetime)
+        (id, user_id, place_uuid, dish_text, note_text, verdict, visit_datetime)
       VALUES
-        (${`seed-checkin-${i + 1}`}, ${USER_ID}, ${placeId}, ${placeId}, ${placeName},
-         ${lat}, ${lng}, ${dish}, ${note}, ${verdict}, ${visitDatetime})
+        (${`seed-checkin-${i + 1}`}, ${USER_ID}, ${placeId},
+         ${dish}, ${note}, ${verdict}, ${visitDatetime})
       ON CONFLICT (id) DO NOTHING
     `;
   }

--- a/src/app/api/checkins/[id]/route.test.ts
+++ b/src/app/api/checkins/[id]/route.test.ts
@@ -281,7 +281,7 @@ describe('PUT /api/checkins/[id]', () => {
     expect(data.noteText).toBe('Great!');
   });
 
-  it('should require placeId', async () => {
+  it('does not require place fields (place is not editable)', async () => {
     (auth as Mock).mockResolvedValue({
       user: { id: 'user-123', email: 'test@example.com' },
       expires: '',
@@ -290,20 +290,27 @@ describe('PUT /api/checkins/[id]', () => {
     const mockSelect = {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: 'checkin-123' }]),
+          limit: vi.fn().mockResolvedValue([{ verdict: 'yes' }]),
         }),
       }),
     };
     (db.select as Mock).mockReturnValue(mockSelect);
 
+    const mockUpdate = {
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ id: 'checkin-123', dishText: 'Pizza' }]),
+        }),
+      }),
+    };
+    (db.update as Mock).mockReturnValue(mockUpdate);
+
+    // Body carries no placeId/placeName/lat/lng — PUT must accept it.
     const request = new NextRequest('http://localhost/api/checkins/123', {
       method: 'PUT',
-      body: JSON.stringify({
-        placeName: 'Test Restaurant',
-        lat: 40.73,
-        lng: -73.99,
-        dishText: 'Pizza',
-      }),
+      body: JSON.stringify({ dishText: 'Pizza', verdict: 'yes' }),
     });
 
     const response = await PUT(request, {
@@ -311,8 +318,12 @@ describe('PUT /api/checkins/[id]', () => {
     });
     const data = await response.json();
 
-    expect(response.status).toBe(400);
-    expect(data.error).toContain('placeId');
+    expect(response.status).toBe(200);
+    expect(data.dishText).toBe('Pizza');
+    // The update never writes place columns.
+    expect(mockUpdate.set).toHaveBeenCalledWith(
+      expect.not.objectContaining({ placeId: expect.anything() })
+    );
   });
 
   it('should enforce dishText length limit (100 chars)', async () => {
@@ -384,41 +395,6 @@ describe('PUT /api/checkins/[id]', () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toContain('500 characters');
-  });
-
-  it('should validate coordinates', async () => {
-    (auth as Mock).mockResolvedValue({
-      user: { id: 'user-123', email: 'test@example.com' },
-      expires: '',
-    });
-
-    const mockSelect = {
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: 'checkin-123' }]),
-        }),
-      }),
-    };
-    (db.select as Mock).mockReturnValue(mockSelect);
-
-    const request = new NextRequest('http://localhost/api/checkins/123', {
-      method: 'PUT',
-      body: JSON.stringify({
-        placeId: 'place-abc',
-        placeName: 'Test Restaurant',
-        lat: 91, // Invalid
-        lng: -73.99,
-        dishText: 'Pizza',
-      }),
-    });
-
-    const response = await PUT(request, {
-      params: Promise.resolve({ id: 'checkin-123' }),
-    });
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data.error).toContain('lat');
   });
 
   it('should update updatedAt timestamp', async () => {

--- a/src/app/api/checkins/[id]/route.ts
+++ b/src/app/api/checkins/[id]/route.ts
@@ -17,9 +17,10 @@ export async function DELETE(
   try {
     const { id } = await params;
 
-    // Check if check-in exists and belongs to user
+    // Check if check-in exists and belongs to user. Explicit column so this
+    // query doesn't reference the deprecated denormalized columns (dropped S5b).
     const existing = await db
-      .select()
+      .select({ id: checkIns.id })
       .from(checkIns)
       .where(and(eq(checkIns.id, id), eq(checkIns.userId, session.user.id)))
       .limit(1);
@@ -63,20 +64,15 @@ export async function PUT(
   try {
     const { id } = await params;
     const body = await request.json();
-    const {
-      placeId,
-      placeName,
-      lat,
-      lng,
-      dishText,
-      noteText,
-      verdict,
-      visitDatetime,
-    } = body;
+    // Editing changes only dish/note/verdict; place isn't editable in the
+    // product, so place fields are neither read nor written here anymore.
+    const { dishText, noteText, verdict, visitDatetime } = body;
 
-    // Check if check-in exists and belongs to user
+    // Check if check-in exists and belongs to user. Explicit columns (no
+    // denormalized place columns — dropped at S5b); verdict feeds the
+    // preserve-on-edit logic below.
     const existing = await db
-      .select()
+      .select({ verdict: checkIns.verdict })
       .from(checkIns)
       .where(and(eq(checkIns.id, id), eq(checkIns.userId, session.user.id)))
       .limit(1);
@@ -89,34 +85,6 @@ export async function PUT(
     }
 
     // Validate required fields
-    if (!placeId || typeof placeId !== 'string') {
-      return NextResponse.json(
-        { error: 'placeId is required and must be a string' },
-        { status: 400 }
-      );
-    }
-
-    if (!placeName || typeof placeName !== 'string') {
-      return NextResponse.json(
-        { error: 'placeName is required and must be a string' },
-        { status: 400 }
-      );
-    }
-
-    if (typeof lat !== 'number' || lat < -90 || lat > 90) {
-      return NextResponse.json(
-        { error: 'lat is required and must be a number between -90 and 90' },
-        { status: 400 }
-      );
-    }
-
-    if (typeof lng !== 'number' || lng < -180 || lng > 180) {
-      return NextResponse.json(
-        { error: 'lng is required and must be a number between -180 and 180' },
-        { status: 400 }
-      );
-    }
-
     if (!dishText || typeof dishText !== 'string') {
       return NextResponse.json(
         { error: 'dishText is required and must be a string' },
@@ -166,14 +134,12 @@ export async function PUT(
       );
     }
 
-    // Update the check-in
+    // Update the check-in. Explicit returning (no denormalized place columns);
+    // the client merges this over the row it already has, so place data it
+    // already holds is preserved.
     const [updated] = await db
       .update(checkIns)
       .set({
-        placeId,
-        placeName,
-        lat,
-        lng,
         dishText,
         noteText: noteText || null,
         // Preserve the existing verdict unless a valid new one is supplied
@@ -183,7 +149,16 @@ export async function PUT(
         updatedAt: new Date(),
       })
       .where(and(eq(checkIns.id, id), eq(checkIns.userId, session.user.id)))
-      .returning();
+      .returning({
+        id: checkIns.id,
+        placeUuid: checkIns.placeUuid,
+        dishText: checkIns.dishText,
+        noteText: checkIns.noteText,
+        verdict: checkIns.verdict,
+        visitDatetime: checkIns.visitDatetime,
+        createdAt: checkIns.createdAt,
+        updatedAt: checkIns.updatedAt,
+      });
 
     return NextResponse.json(updated, { status: 200 });
   } catch (error) {

--- a/src/app/api/checkins/route.test.ts
+++ b/src/app/api/checkins/route.test.ts
@@ -21,6 +21,17 @@ describe('GET /api/checkins', () => {
     vi.clearAllMocks();
   });
 
+  // GET joins places: db.select().from().leftJoin().where().orderBy()
+  function mockGetChain(orderBy: Mock) {
+    return {
+      from: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ orderBy }),
+        }),
+      }),
+    };
+  }
+
   it('should reject unauthenticated requests', async () => {
     (auth as Mock).mockResolvedValue(null);
 
@@ -66,14 +77,9 @@ describe('GET /api/checkins', () => {
       },
     ];
 
-    const mockSelect = {
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockResolvedValue(mockCheckIns),
-        }),
-      }),
-    };
-    (db.select as Mock).mockReturnValue(mockSelect);
+    (db.select as Mock).mockReturnValue(
+      mockGetChain(vi.fn().mockResolvedValue(mockCheckIns))
+    );
 
     const response = await GET();
     const data = await response.json();
@@ -90,14 +96,9 @@ describe('GET /api/checkins', () => {
       expires: '',
     });
 
-    const mockSelect = {
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockResolvedValue([]),
-        }),
-      }),
-    };
-    (db.select as Mock).mockReturnValue(mockSelect);
+    (db.select as Mock).mockReturnValue(
+      mockGetChain(vi.fn().mockResolvedValue([]))
+    );
 
     const response = await GET();
     const data = await response.json();
@@ -112,14 +113,9 @@ describe('GET /api/checkins', () => {
       expires: '',
     });
 
-    const mockSelect = {
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockRejectedValue(new Error('DB connection failed')),
-        }),
-      }),
-    };
-    (db.select as Mock).mockReturnValue(mockSelect);
+    (db.select as Mock).mockReturnValue(
+      mockGetChain(vi.fn().mockRejectedValue(new Error('DB connection failed')))
+    );
 
     const response = await GET();
     const data = await response.json();

--- a/src/app/api/checkins/route.ts
+++ b/src/app/api/checkins/route.ts
@@ -12,9 +12,28 @@ export async function GET() {
   }
 
   try {
+    // Place data (name/coords/Google ID) comes from the places join now, not the
+    // deprecated denormalized check_ins columns (removed at S5b). Explicit column
+    // list so this query never references those columns — that's what makes the
+    // S5b DROP safe to run while this version is still serving. leftJoin so a
+    // (should-not-exist post-migration) unlinked row still returns.
     const userCheckIns = await db
-      .select()
+      .select({
+        id: checkIns.id,
+        placeUuid: checkIns.placeUuid,
+        placeName: places.name,
+        placeId: places.googlePlaceId,
+        lat: places.lat,
+        lng: places.lng,
+        dishText: checkIns.dishText,
+        noteText: checkIns.noteText,
+        verdict: checkIns.verdict,
+        visitDatetime: checkIns.visitDatetime,
+        createdAt: checkIns.createdAt,
+        updatedAt: checkIns.updatedAt,
+      })
       .from(checkIns)
+      .leftJoin(places, eq(checkIns.placeUuid, places.id))
       .where(eq(checkIns.userId, session.user.id))
       .orderBy(desc(checkIns.visitDatetime));
 
@@ -209,23 +228,41 @@ export async function POST(request: NextRequest) {
       .onConflictDoUpdate({ target: places.googlePlaceId, set: placeUpdate })
       .returning();
 
+    // The check-in points at the place via place_uuid only; the denormalized
+    // place columns are no longer written (removed at S5b). Explicit returning so
+    // this INSERT never names those columns — keeping the S5b DROP safe.
     const [newCheckIn] = await db
       .insert(checkIns)
       .values({
         userId: session.user.id,
         placeUuid: place.id,
-        placeId,
-        placeName,
-        lat,
-        lng,
         dishText,
         noteText: noteText || null,
         verdict,
         visitDatetime: visitDate,
       })
-      .returning();
+      .returning({
+        id: checkIns.id,
+        placeUuid: checkIns.placeUuid,
+        dishText: checkIns.dishText,
+        noteText: checkIns.noteText,
+        verdict: checkIns.verdict,
+        visitDatetime: checkIns.visitDatetime,
+        createdAt: checkIns.createdAt,
+        updatedAt: checkIns.updatedAt,
+      });
 
-    return NextResponse.json(newCheckIn, { status: 201 });
+    // Shape the response like GET's rows: place data from the place we upserted.
+    return NextResponse.json(
+      {
+        ...newCheckIn,
+        placeName: place.name,
+        placeId: place.googlePlaceId,
+        lat: place.lat,
+        lng: place.lng,
+      },
+      { status: 201 }
+    );
   } catch (error) {
     console.error('Error creating check-in:', error);
 

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -8,10 +8,12 @@ import type { Verdict } from '@/lib/verdict';
 interface CheckIn {
   id: string;
   placeUuid: string | null;
-  placeId: string;
-  placeName: string;
-  lat: number;
-  lng: number;
+  // Place fields come from the places join now and are null only for a row
+  // that somehow never got linked (shouldn't happen post-S5 migration).
+  placeId: string | null;
+  placeName: string | null;
+  lat: number | null;
+  lng: number | null;
   dishText: string;
   noteText: string | null;
   verdict: Verdict | null;
@@ -114,10 +116,6 @@ export default function HistoryPage() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          placeId: editingCheckIn.placeId,
-          placeName: editingCheckIn.placeName,
-          lat: editingCheckIn.lat,
-          lng: editingCheckIn.lng,
           dishText: editDishText.trim(),
           noteText: editNoteText.trim() || null,
           verdict: editVerdict,
@@ -132,9 +130,13 @@ export default function HistoryPage() {
 
       const updated = await response.json();
 
-      // Update in state
+      // Merge the update over the existing row: the PUT response carries only
+      // the check-in's own fields (dish/note/verdict/…), so keep the place data
+      // we already have — editing never changes the place.
       setCheckIns(
-        checkIns.map(c => (c.id === editingCheckIn.id ? updated : c))
+        checkIns.map(c =>
+          c.id === editingCheckIn.id ? { ...c, ...updated } : c
+        )
       );
 
       handleCancelEdit();
@@ -231,7 +233,7 @@ export default function HistoryPage() {
                       </a>
                     ) : (
                       <p className="text-gray-600 dark:text-gray-400 mt-1">
-                        {checkIn.placeName}
+                        {checkIn.placeName ?? 'Unknown place'}
                       </p>
                     )}
                   </div>
@@ -249,14 +251,20 @@ export default function HistoryPage() {
                 )}
 
                 <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 flex justify-between items-center">
-                  <a
-                    href={`https://www.google.com/maps/search/?api=1&query=${checkIn.lat},${checkIn.lng}&query_place_id=${checkIn.placeId}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                  >
-                    View on Google Maps →
-                  </a>
+                  {checkIn.lat != null &&
+                  checkIn.lng != null &&
+                  checkIn.placeId ? (
+                    <a
+                      href={`https://www.google.com/maps/search/?api=1&query=${checkIn.lat},${checkIn.lng}&query_place_id=${checkIn.placeId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      View on Google Maps →
+                    </a>
+                  ) : (
+                    <span />
+                  )}
                   <div className="flex gap-2">
                     <button
                       onClick={() => handleEditClick(checkIn)}

--- a/src/app/places/[id]/page.test.tsx
+++ b/src/app/places/[id]/page.test.tsx
@@ -83,18 +83,25 @@ describe('PlacePage', () => {
     expect(notFound).toHaveBeenCalled();
   });
 
-  it('renders the place and the user’s visits when authorized', async () => {
+  it('renders the place, a grouped dish summary, and the visit log', async () => {
     (auth as Mock).mockResolvedValue({ user: { id: 'user-1' }, expires: '' });
     (db.select as Mock)
       .mockReturnValueOnce(mockPlaceQuery([place]))
       .mockReturnValueOnce(
         mockVisitsQuery([
           {
-            id: 'checkin-1',
-            dishText: 'Morning bun',
-            noteText: 'Worth the line.',
+            id: 'checkin-2',
+            dishText: 'Morning Bun', // latest spelling
+            noteText: null,
             verdict: 'yes',
             visitDatetime: new Date('2025-06-01T12:00:00Z'),
+          },
+          {
+            id: 'checkin-1',
+            dishText: 'morning bun ', // groups with the above
+            noteText: 'Worth the line.',
+            verdict: 'maybe',
+            visitDatetime: new Date('2025-01-01T12:00:00Z'),
           },
         ])
       );
@@ -103,8 +110,15 @@ describe('PlacePage', () => {
 
     expect(screen.getByText('Tartine Bakery')).toBeInTheDocument();
     expect(screen.getByText('600 Guerrero St')).toBeInTheDocument();
-    expect(screen.getByText('Morning bun')).toBeInTheDocument();
+
+    // Dish summary groups the two spellings into one row: "2 visits".
+    expect(screen.getByText('What you order here')).toBeInTheDocument();
+    expect(screen.getByText('2 visits')).toBeInTheDocument();
+
+    // Visit log shows both individual visits below.
+    expect(screen.getByText('All visits · 2')).toBeInTheDocument();
     expect(screen.getByText('Worth the line.')).toBeInTheDocument();
+
     expect(notFound).not.toHaveBeenCalled();
   });
 });

--- a/src/app/places/[id]/page.tsx
+++ b/src/app/places/[id]/page.tsx
@@ -4,11 +4,13 @@ import { auth } from '@/auth';
 import { db } from '@/lib/db/client';
 import { checkIns, places } from '@/lib/db/schema';
 import { VerdictBadge } from '@/components/verdict-badge';
+import { rollupDishes } from '@/lib/dishes/rollup';
 
-// A place's page (S4): every visit *you* logged here, newest first. The first
-// real payoff of normalizing places — your history at a single place.
-// Auth-gated and scoped to the signed-in user; a place you've never visited
-// 404s rather than leaking that it exists.
+// A place's page (S4/S5): leads with the dish summary — each dish you've
+// ordered here, grouped, with visit count and latest verdict ("should I get the
+// club sandwich again?") — then the full visit log below. Auth-gated and scoped
+// to the signed-in user; a place you've never visited 404s rather than leaking
+// that it exists.
 
 function formatDate(date: Date) {
   return new Intl.DateTimeFormat('en-US', {
@@ -40,8 +42,15 @@ export default async function PlacePage({
     notFound();
   }
 
+  // Explicit columns — no denormalized place columns (dropped at S5b).
   const visits = await db
-    .select()
+    .select({
+      id: checkIns.id,
+      dishText: checkIns.dishText,
+      noteText: checkIns.noteText,
+      verdict: checkIns.verdict,
+      visitDatetime: checkIns.visitDatetime,
+    })
     .from(checkIns)
     .where(
       and(eq(checkIns.placeUuid, id), eq(checkIns.userId, session.user.id))
@@ -52,6 +61,9 @@ export default async function PlacePage({
   if (visits.length === 0) {
     notFound();
   }
+
+  // Read-time dish rollup (S5): group visits by dish for the summary.
+  const dishes = rollupDishes(visits);
 
   const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${place.lat},${place.lng}&query_place_id=${place.googlePlaceId}`;
 
@@ -84,8 +96,37 @@ export default async function PlacePage({
           </a>
         </div>
 
+        {/* Dish summary — the "should I get the club sandwich?" screen. */}
         <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
-          {visits.length} {visits.length === 1 ? 'visit' : 'visits'}
+          What you order here
+        </h2>
+        <div className="space-y-3 mb-10">
+          {dishes.map(dish => (
+            <div
+              key={dish.key}
+              className="bg-white dark:bg-gray-800 rounded-lg shadow p-5 flex items-center justify-between gap-4"
+            >
+              <div className="min-w-0">
+                <div className="text-lg font-semibold text-gray-900 dark:text-white truncate">
+                  {dish.displayName}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {dish.count} {dish.count === 1 ? 'visit' : 'visits'}
+                </div>
+              </div>
+              {dish.latestVerdict ? (
+                <VerdictBadge verdict={dish.latestVerdict} />
+              ) : (
+                <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                  No verdict yet
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
+          All visits · {visits.length}
         </h2>
 
         <div className="space-y-4">

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -100,22 +100,21 @@ export const checkIns = pgTable('check_ins', {
   userId: text('user_id')
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
-  // FK to the normalized place (S4). Nullable for one release: the migration is
-  // expand-only (backfilled from the denormalized columns below), and the
-  // previously-deployed version keeps writing check-ins without it during the
-  // migrate-on-deploy window. New writes always set it. S5 drops the
-  // denormalized place_id/place_name/lat/lng once this is the source of truth.
-  //
-  // S5 OBLIGATION: check-ins written by the old code during the S4 deploy
-  // window land with place_uuid = NULL and are never re-linked (0003 runs once).
-  // Before S5 drops the denormalized columns, its migration MUST re-run the
-  // 0003 backfill block (insert missing places + UPDATE ... WHERE place_uuid IS
-  // NULL) or those rows lose their place identity permanently.
+  // FK to the normalized place — the source of truth for place data as of S5.
+  // Application code reads place name/coords via this join and no longer touches
+  // the denormalized columns below. Still nullable only because rows written by
+  // old code during the S4 deploy window predate it; the S5 migration re-links
+  // those, so in practice every row is linked.
   placeUuid: text('place_uuid').references(() => places.id),
-  placeId: text('place_id').notNull(),
-  placeName: text('place_name').notNull(),
-  lat: doublePrecision('lat').notNull(),
-  lng: doublePrecision('lng').notNull(),
+  // DEPRECATED denormalized place columns (S4 → removed at S5b). As of S5 no
+  // code reads or writes these — reads come from the places join, writes stopped
+  // — so they're nullable and inert, kept one release as a safety net. The S5b
+  // migration DROPs them; because S5 code already ignores them, that drop is
+  // safe to run while S5 is still serving (nothing SELECTs or INSERTs them).
+  placeId: text('place_id'),
+  placeName: text('place_name'),
+  lat: doublePrecision('lat'),
+  lng: doublePrecision('lng'),
   dishText: varchar('dish_text', { length: 100 }).notNull(),
   noteText: varchar('note_text', { length: 500 }),
   verdict: verdictEnum('verdict'),

--- a/src/lib/dishes/rollup.test.ts
+++ b/src/lib/dishes/rollup.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeDishKey, rollupDishes, type DishVisit } from './rollup';
+
+describe('normalizeDishKey', () => {
+  it('lowercases', () => {
+    expect(normalizeDishKey('Club Sandwich')).toBe('club sandwich');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeDishKey('  club sandwich  ')).toBe('club sandwich');
+  });
+
+  it('collapses internal whitespace', () => {
+    expect(normalizeDishKey('club\t sandwich')).toBe('club sandwich');
+    expect(normalizeDishKey('club   sandwich')).toBe('club sandwich');
+  });
+
+  it('strips trailing punctuation', () => {
+    expect(normalizeDishKey('Club Sandwich.')).toBe('club sandwich');
+    expect(normalizeDishKey('Club Sandwich!!!')).toBe('club sandwich');
+    expect(normalizeDishKey('Club Sandwich ...')).toBe('club sandwich');
+  });
+
+  it('maps casing/whitespace/punctuation variants to one key', () => {
+    const variants = [
+      'Club Sandwich',
+      'club sandwich ',
+      '  CLUB   SANDWICH',
+      'club sandwich.',
+    ];
+    const keys = new Set(variants.map(normalizeDishKey));
+    expect(keys.size).toBe(1);
+  });
+
+  it('keeps genuinely distinct dishes distinct', () => {
+    expect(normalizeDishKey('Club Sandwich')).not.toBe(
+      normalizeDishKey('Turkey Club')
+    );
+  });
+
+  it('does not strip internal punctuation', () => {
+    // Meaningful punctuation mid-name must survive.
+    expect(normalizeDishKey('Fish & Chips')).toBe('fish & chips');
+    expect(normalizeDishKey('PB&J')).toBe('pb&j');
+  });
+
+  it('does not collapse all-punctuation names to one empty key', () => {
+    expect(normalizeDishKey('???')).toBe('???');
+    expect(normalizeDishKey('...')).not.toBe(normalizeDishKey('!!!'));
+  });
+});
+
+describe('rollupDishes', () => {
+  const visit = (
+    dishText: string,
+    verdict: DishVisit['verdict'],
+    iso: string
+  ): DishVisit => ({ dishText, verdict, visitDatetime: new Date(iso) });
+
+  it('groups variant spellings and counts visits', () => {
+    const groups = rollupDishes([
+      visit('Club Sandwich', 'yes', '2025-01-01'),
+      visit('club sandwich ', 'maybe', '2025-02-01'),
+      visit('CLUB SANDWICH.', 'no', '2025-03-01'),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(3);
+  });
+
+  it('uses the most recent visit for display name and verdict', () => {
+    const groups = rollupDishes([
+      visit('club sandwich', 'no', '2025-01-01'),
+      visit('Club Sandwich', 'yes', '2025-06-01'), // latest
+      visit('CLUB SANDWICH', 'maybe', '2025-03-01'),
+    ]);
+
+    expect(groups[0].displayName).toBe('Club Sandwich');
+    expect(groups[0].latestVerdict).toBe('yes');
+  });
+
+  it('separates distinct dishes', () => {
+    const groups = rollupDishes([
+      visit('Club Sandwich', 'yes', '2025-01-01'),
+      visit('Caesar Salad', 'maybe', '2025-01-02'),
+      visit('Club Sandwich', 'yes', '2025-01-03'),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    const club = groups.find(g => g.key === 'club sandwich');
+    const caesar = groups.find(g => g.key === 'caesar salad');
+    expect(club?.count).toBe(2);
+    expect(caesar?.count).toBe(1);
+  });
+
+  it('orders by visit count, then most recent visit', () => {
+    const groups = rollupDishes([
+      visit('Burger', 'yes', '2025-05-01'), // 1 visit, recent
+      visit('Fries', 'yes', '2025-01-01'), // 3 visits, older
+      visit('Fries', 'yes', '2025-01-02'),
+      visit('Fries', 'yes', '2025-01-03'),
+      visit('Shake', 'maybe', '2025-06-01'), // 1 visit, most recent
+    ]);
+
+    expect(groups.map(g => g.displayName)).toEqual([
+      'Fries', // most visits
+      'Shake', // tie on count(1) with Burger, more recent
+      'Burger',
+    ]);
+  });
+
+  it('handles a null verdict on the latest visit', () => {
+    const groups = rollupDishes([
+      visit('Tea', 'yes', '2025-01-01'),
+      visit('Tea', null, '2025-02-01'),
+    ]);
+
+    expect(groups[0].latestVerdict).toBeNull();
+  });
+
+  it('returns an empty array for no visits', () => {
+    expect(rollupDishes([])).toEqual([]);
+  });
+});

--- a/src/lib/dishes/rollup.ts
+++ b/src/lib/dishes/rollup.ts
@@ -1,0 +1,84 @@
+// Read-time dish grouping (S5). Deliberately NOT a table or stored slug:
+// canonicalization rules ("Coke" == "Coca-Cola"? "fries" == "french fries"?)
+// aren't knowable until real data exists. A pure function is trivially
+// changeable and becomes the seed of the dish-entity work at the horizon (H3).
+//
+// The rule today is intentionally conservative — only collapse variants that are
+// unambiguously the same order: case, surrounding/internal whitespace, and
+// trailing punctuation. Nothing semantic.
+
+import type { Verdict } from '@/lib/verdict';
+
+export interface DishVisit {
+  dishText: string;
+  verdict: Verdict | null;
+  visitDatetime: Date;
+}
+
+export interface DishGroup {
+  /** Normalized grouping key — an implementation detail, not shown to users. */
+  key: string;
+  /** The most recent visit's original spelling, shown as the dish name. */
+  displayName: string;
+  /** How many visits ordered this dish. */
+  count: number;
+  /** The most recent visit's verdict (may be null for legacy visits). */
+  latestVerdict: Verdict | null;
+}
+
+/**
+ * Normalize a dish name into its grouping key: lowercase, trim, collapse
+ * internal whitespace to single spaces, strip trailing punctuation. Two names
+ * that differ only in those respects share a key and group together.
+ */
+export function normalizeDishKey(dish: string): string {
+  const base = dish.toLowerCase().replace(/\s+/g, ' ').trim();
+  const stripped = base.replace(/[\s.,!?;:]+$/, '').trim();
+  // Fall back to the un-stripped form for all-punctuation names ("???") so they
+  // don't all collapse into one empty-key group.
+  return stripped || base;
+}
+
+/**
+ * Group a place's visits by normalized dish, newest-first within each group so
+ * the display name and verdict reflect the latest order. Groups are returned
+ * ordered by visit count (your usual first), ties broken by most recent visit.
+ */
+export function rollupDishes(visits: readonly DishVisit[]): DishGroup[] {
+  const groups = new Map<string, DishVisit[]>();
+
+  for (const visit of visits) {
+    const key = normalizeDishKey(visit.dishText);
+    const bucket = groups.get(key);
+    if (bucket) {
+      bucket.push(visit);
+    } else {
+      groups.set(key, [visit]);
+    }
+  }
+
+  const entries: { latestVisit: Date; group: DishGroup }[] = [];
+  for (const [key, bucket] of groups) {
+    const latest = bucket.reduce((a, b) =>
+      b.visitDatetime > a.visitDatetime ? b : a
+    );
+    entries.push({
+      latestVisit: latest.visitDatetime,
+      group: {
+        key,
+        displayName: latest.dishText,
+        count: bucket.length,
+        latestVerdict: latest.verdict,
+      },
+    });
+  }
+
+  // Your usual first: most visits, ties broken by most recent visit.
+  entries.sort(
+    (a, b) =>
+      b.group.count - a.group.count ||
+      b.latestVisit.getTime() - a.latestVisit.getTime()
+  );
+
+  return entries.map(entry => entry.group);
+}


### PR DESCRIPTION
## What the user sees

Place pages now **lead with a dish summary** — each dish you've ordered there, grouped, with visit count and latest verdict ("Morning Bun · 2 visits · Yes"). The full visit log moves below it. This is the "should I get the club sandwich again?" screen.

## Dish rollup (the feature)

- Read-time grouping only — a pure function in `src/lib/dishes/rollup.ts` (lowercase, trim, collapse whitespace, strip trailing punctuation). **No `dishes` table, no stored slug**: canonicalization rules aren't knowable until real data exists; a read-time function is trivially changeable and seeds the H3 dish-entity work.
- Display name + verdict come from the **latest** visit in each group; groups are ordered by visit count (your usual first), ties broken by recency.
- Unit-tested hard: casing/whitespace/punctuation variants map together, distinct dishes stay distinct, internal punctuation (`Fish & Chips`) survives, all-punctuation names don't collapse into one empty group.

## Retiring the denormalized `check_ins` place columns — phase 1 of 2

Per the repo's **expand-only migration policy** (migrations run during the production build while the previous version still serves), the destructive DROP is **split across two deploys**:

- **This PR (phase 1):** stop the app from *reading or writing* `place_id`/`place_name`/`lat`/`lng` on `check_ins`, and make them nullable.
  - `GET /api/checkins` sources place data from a `places` leftJoin (explicit column list).
  - Place page + `[id]` existence checks use explicit selects; `POST`/`PUT` stop writing the columns and use explicit `.returning()`; history sources place data from the join and merges `PUT` responses over the existing row (place isn't editable).
  - **Migration `0004`**: re-links any orphan check-ins (`place_uuid IS NULL` from the S4 deploy window) using the denormalized columns *while they still exist*, then `DROP NOT NULL` on the four columns. Re-link is idempotent (`ON CONFLICT DO NOTHING` + `WHERE place_uuid IS NULL`) and ordered before the NOT-NULL drops.
  - Seed script writes `place_uuid` only.
- **Follow-up (S5b):** a pure `DROP COLUMN` migration — safe because *this* version already ignores the columns, so it can run mid-deploy without breaking the serving code.

The columns stay defined in `schema.ts` (now nullable) for one release as a safety net; no query names them, so keeping them is inert.

## Tests
129 pass. New: dish rollup (grouping/normalization/ordering); place-page dish-summary rendering. Updated: checkins GET (places join mock), PUT (place fields no longer required/validated).

## Migration / deploy notes
- `0004` is expand-only + idempotent; runs automatically via `vercel-build`. S4 code serving during the build keeps working (columns still present, `place_uuid` always set), so no new orphans appear after the re-link.
- **S5b is required next** to actually drop the columns.

## Reviewed
Adversarial review pass focused on the S5b-drop safety property (verified no serving query still references the four columns), migration idempotency/ordering, and rollup edge cases. Took its nit on all-punctuation dish names; left the preexisting PUT `visitDatetime` behavior as out-of-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)