### PR TITLE
PostGIS + "Near me" home screen

### DIFF
--- a/drizzle/0006_common_siren.sql
+++ b/drizzle/0006_common_siren.sql
@@ -1,0 +1,3 @@
+CREATE EXTENSION IF NOT EXISTS postgis;--> statement-breakpoint
+ALTER TABLE "places" ADD COLUMN "location" geography(Point, 4326) GENERATED ALWAYS AS (ST_MakePoint("lng", "lat")::geography) STORED;--> statement-breakpoint
+CREATE INDEX "places_location_idx" ON "places" USING gist ("location");

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,455 @@
+{
+  "id": "1bc73e04-0044-402b-b1ad-7f1bf7c02e95",
+  "prevId": "08afcb6a-6cbf-47be-85f1-def1912d17e3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": ["provider", "provider_account_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_uuid": {
+          "name": "place_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dish_text": {
+          "name": "dish_text",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_text": {
+          "name": "note_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visit_datetime": {
+          "name": "visit_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "check_ins_place_uuid_places_id_fk": {
+          "name": "check_ins_place_uuid_places_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "places",
+          "columnsFrom": ["place_uuid"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "geography(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(\"lng\", \"lat\")::geography",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "places_location_idx": {
+          "name": "places_location_idx",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["google_place_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.verdict": {
+      "name": "verdict",
+      "schema": "public",
+      "values": ["yes", "maybe", "no"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1783907141166,
       "tag": "0005_woozy_paibok",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1783909685188,
+      "tag": "0006_common_siren",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/places/near-me/route.test.ts
+++ b/src/app/api/places/near-me/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }));
+vi.mock('@/lib/places/near-me', () => ({ findPlacesNearUser: vi.fn() }));
+
+import { GET } from './route';
+import { auth } from '@/auth';
+import { findPlacesNearUser } from '@/lib/places/near-me';
+
+const authed = () =>
+  (auth as Mock).mockResolvedValue({
+    user: { id: 'user-123', email: 'test@example.com' },
+    expires: '',
+  });
+
+function req(query: string) {
+  return new NextRequest(`http://localhost/api/places/near-me${query}`);
+}
+
+describe('GET /api/places/near-me', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects unauthenticated requests', async () => {
+    (auth as Mock).mockResolvedValue(null);
+    const res = await GET(req('?lat=37.77&lng=-122.42'));
+    expect(res.status).toBe(401);
+    expect(findPlacesNearUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing coordinates', async () => {
+    authed();
+    const res = await GET(req(''));
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.error).toContain('lat');
+  });
+
+  it('rejects out-of-range latitude', async () => {
+    authed();
+    const res = await GET(req('?lat=91&lng=-122.42'));
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.error).toContain('lat');
+  });
+
+  it('rejects out-of-range longitude', async () => {
+    authed();
+    const res = await GET(req('?lat=37.77&lng=200'));
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.error).toContain('lng');
+  });
+
+  it('returns distance-ordered places for valid coords', async () => {
+    authed();
+    const places = [
+      {
+        id: 'p1',
+        name: 'Blue Bottle',
+        formattedAddress: '66 Mint St',
+        distanceMeters: 120,
+        topDish: 'Cappuccino',
+        topVerdict: 'yes',
+      },
+    ];
+    (findPlacesNearUser as Mock).mockResolvedValue(places);
+
+    const res = await GET(req('?lat=37.77&lng=-122.42'));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.places).toEqual(places);
+    expect(findPlacesNearUser).toHaveBeenCalledWith({
+      userId: 'user-123',
+      lat: 37.77,
+      lng: -122.42,
+    });
+  });
+
+  it('surfaces query failures as 500', async () => {
+    authed();
+    (findPlacesNearUser as Mock).mockRejectedValue(new Error('PostGIS down'));
+    const res = await GET(req('?lat=37.77&lng=-122.42'));
+    const data = await res.json();
+    expect(res.status).toBe(500);
+    expect(data.error).toBe('PostGIS down');
+  });
+});

--- a/src/app/api/places/near-me/route.ts
+++ b/src/app/api/places/near-me/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { findPlacesNearUser } from '@/lib/places/near-me';
+
+// GET /api/places/near-me?lat=&lng= — the signed-in user's places nearest a
+// point, each with its top dish and verdict. Backs the "near me" home screen
+// (S6); coords come from the browser's geolocation, hence a query-param GET.
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const latParam = searchParams.get('lat');
+  const lngParam = searchParams.get('lng');
+
+  // Parse explicitly: Number(null)/Number('') both coerce to 0 (a valid coord),
+  // so a missing param would silently read as 0,0 — reject it up front.
+  const lat = latParam === null || latParam === '' ? NaN : Number(latParam);
+  const lng = lngParam === null || lngParam === '' ? NaN : Number(lngParam);
+
+  // Reject missing/NaN/out-of-range coords — same bounds as the check-in route.
+  if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
+    return NextResponse.json(
+      { error: 'lat is required and must be a number between -90 and 90' },
+      { status: 400 }
+    );
+  }
+  if (!Number.isFinite(lng) || lng < -180 || lng > 180) {
+    return NextResponse.json(
+      { error: 'lng is required and must be a number between -180 and 180' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const places = await findPlacesNearUser({
+      userId: session.user.id,
+      lat,
+      lng,
+    });
+    return NextResponse.json({ places }, { status: 200 });
+  } catch (error) {
+    console.error('Error fetching nearby places:', error);
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -21,20 +21,19 @@ describe('Home (Landing Page)', () => {
     vi.clearAllMocks();
   });
 
-  it('should redirect authenticated users to /history', async () => {
+  it('should show the near-me home for authenticated users (no redirect)', async () => {
     // @ts-expect-error - mocking NextAuth function
     vi.mocked(auth).mockResolvedValue({
       user: { id: 'user-123', email: 'test@example.com' },
       expires: '',
     } as Session);
 
-    try {
-      await Home();
-    } catch {
-      // Redirect throws, which is expected
-    }
+    const component = await Home();
+    render(component);
 
-    expect(mockRedirect).toHaveBeenCalledWith('/history');
+    // Signed-in users get the "near me" home (S6), not a redirect.
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(screen.getByText('Near you')).toBeInTheDocument();
   });
 
   it('should show landing page for unauthenticated users', async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
 import { auth } from '@/auth';
-import { redirect } from 'next/navigation';
+import { NearMeHome } from '@/components/near-me-home';
 
 export default async function Home() {
   const session = await auth();
 
-  // Redirect authenticated users to their history
+  // Signed-in users land on their "near me" home (S6) — the app's front door,
+  // their places sorted by distance — instead of the bare history redirect.
   if (session?.user) {
-    redirect('/history');
+    return <NearMeHome />;
   }
 
   // Landing page for signed-out users

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -18,7 +18,27 @@ export async function Navbar() {
           <div className="flex items-center gap-4">
             {session?.user ? (
               <>
-                <span className="text-sm text-gray-700">
+                <div className="flex items-center gap-4">
+                  <Link
+                    href="/"
+                    className="text-sm font-medium text-gray-700 hover:text-gray-900"
+                  >
+                    Home
+                  </Link>
+                  <Link
+                    href="/check-in"
+                    className="text-sm font-medium text-gray-700 hover:text-gray-900"
+                  >
+                    Check in
+                  </Link>
+                  <Link
+                    href="/history"
+                    className="text-sm font-medium text-gray-700 hover:text-gray-900"
+                  >
+                    History
+                  </Link>
+                </div>
+                <span className="hidden text-sm text-gray-700 sm:inline">
                   {session.user.email}
                 </span>
                 <SignOutButton />

--- a/src/components/near-me-home.test.tsx
+++ b/src/components/near-me-home.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NearMeHome } from './near-me-home';
+
+// NearMeHome owns the geolocation → fetch flow. These tests cover the graceful
+// paths (unavailable / denied / success) without a real browser or DB.
+
+describe('NearMeHome', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    // Reset geolocation between tests.
+    delete (navigator as unknown as { geolocation?: unknown }).geolocation;
+  });
+
+  it('falls back (not a crash) when geolocation is unavailable', async () => {
+    // jsdom has no navigator.geolocation by default; component must degrade.
+    render(<NearMeHome />);
+
+    expect(
+      await screen.findByText('Turn on location to see places near you')
+    ).toBeInTheDocument();
+    // The history escape hatch is offered.
+    expect(
+      screen.getByRole('link', { name: 'View your history' })
+    ).toHaveAttribute('href', '/history');
+  });
+
+  it('shows the enable-location prompt when permission is denied', async () => {
+    const getCurrentPosition = vi.fn((_success, error) => {
+      error({ code: 1, PERMISSION_DENIED: 1 });
+    });
+    // @ts-expect-error - stub geolocation
+    navigator.geolocation = { getCurrentPosition };
+
+    render(<NearMeHome />);
+
+    expect(
+      await screen.findByText('Turn on location to see places near you')
+    ).toBeInTheDocument();
+  });
+
+  it('renders distance-ordered place cards on success', async () => {
+    const getCurrentPosition = vi.fn(success => {
+      success({ coords: { latitude: 37.77, longitude: -122.42 } });
+    });
+    // @ts-expect-error - stub geolocation
+    navigator.geolocation = { getCurrentPosition };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          places: [
+            {
+              id: 'p1',
+              name: 'Blue Bottle Coffee',
+              formattedAddress: '66 Mint St',
+              distanceMeters: 120,
+              topDish: 'Cappuccino',
+              topVerdict: 'yes',
+            },
+          ],
+        }),
+      })
+    );
+
+    render(<NearMeHome />);
+
+    expect(await screen.findByText('Blue Bottle Coffee')).toBeInTheDocument();
+    expect(screen.getByText('Cappuccino')).toBeInTheDocument();
+    expect(screen.getByText('120m')).toBeInTheDocument();
+    // Card links to the place page.
+    expect(
+      screen.getByRole('link', { name: /Blue Bottle Coffee/ })
+    ).toHaveAttribute('href', '/places/p1');
+  });
+
+  it('shows the empty state when there are no nearby places', async () => {
+    const getCurrentPosition = vi.fn(success => {
+      success({ coords: { latitude: 37.77, longitude: -122.42 } });
+    });
+    // @ts-expect-error - stub geolocation
+    navigator.geolocation = { getCurrentPosition };
+
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: async () => ({ places: [] }) })
+    );
+
+    render(<NearMeHome />);
+
+    // Empty within the widest radius must still offer the history escape hatch,
+    // not read as "you have no places".
+    await waitFor(() =>
+      expect(screen.getByText(/No places within 50/)).toBeInTheDocument()
+    );
+    expect(
+      screen.getByRole('link', { name: 'View all your places' })
+    ).toHaveAttribute('href', '/history');
+  });
+});

--- a/src/components/near-me-home.tsx
+++ b/src/components/near-me-home.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { VerdictBadge } from '@/components/verdict-badge';
+import { formatDistance } from '@/lib/places/distance';
+import type { Verdict } from '@/lib/verdict';
+
+interface NearbyPlace {
+  id: string;
+  name: string;
+  formattedAddress: string | null;
+  distanceMeters: number;
+  topDish: string | null;
+  topVerdict: Verdict | null;
+}
+
+type State =
+  | { status: 'locating' } // asking the browser for the user's position
+  | { status: 'loading' } // have coords, fetching nearby places
+  | { status: 'ready'; places: NearbyPlace[] }
+  | { status: 'fallback'; reason: 'denied' | 'unavailable' | 'failed' }
+  | { status: 'error'; message: string };
+
+// The signed-in home screen (S6): "Places you've been, near you." Geolocation is
+// client-only, so this component owns the whole flow — ask for position, fetch
+// the near-me API, and degrade gracefully to a history link if location is
+// unavailable or denied (never a dead screen).
+export function NearMeHome() {
+  const [state, setState] = useState<State>({ status: 'locating' });
+
+  const locate = useCallback(() => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setState({ status: 'fallback', reason: 'unavailable' });
+      return;
+    }
+
+    setState({ status: 'locating' });
+    navigator.geolocation.getCurrentPosition(
+      async position => {
+        setState({ status: 'loading' });
+        try {
+          const { latitude, longitude } = position.coords;
+          const res = await fetch(
+            `/api/places/near-me?lat=${latitude}&lng=${longitude}`
+          );
+          if (!res.ok) {
+            const data = await res.json();
+            throw new Error(data.error || 'Failed to load nearby places');
+          }
+          const data = await res.json();
+          setState({ status: 'ready', places: data.places });
+        } catch (err) {
+          setState({
+            status: 'error',
+            message:
+              err instanceof Error
+                ? err.message
+                : 'Failed to load nearby places',
+          });
+        }
+      },
+      error => {
+        // Permission denied gets a "turn it on" nudge; other failures (position
+        // unavailable, timeout) get a generic retry — both fall back to history.
+        setState({
+          status: 'fallback',
+          reason: error.code === error.PERMISSION_DENIED ? 'denied' : 'failed',
+        });
+      },
+      // Without a timeout the default is infinite: on a machine whose location
+      // fix stalls, the callback never fires and the spinner hangs forever. Cap
+      // it so a stall degrades to the retry fallback instead.
+      { timeout: 10_000, maximumAge: 60_000 }
+    );
+  }, []);
+
+  useEffect(() => {
+    locate();
+  }, [locate]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8 gap-4">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Near you
+          </h1>
+          <a
+            href="/check-in"
+            className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors whitespace-nowrap"
+          >
+            New Check-In
+          </a>
+        </div>
+
+        {(state.status === 'locating' || state.status === 'loading') && (
+          <div className="text-center py-12">
+            <div className="animate-spin h-12 w-12 border-4 border-blue-600 border-t-transparent rounded-full mx-auto"></div>
+            <p className="mt-4 text-gray-600 dark:text-gray-400">
+              {state.status === 'locating'
+                ? 'Finding your location…'
+                : 'Looking for your places nearby…'}
+            </p>
+          </div>
+        )}
+
+        {state.status === 'error' && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
+            <p className="text-red-600 dark:text-red-400 mb-4">
+              {state.message}
+            </p>
+            <button
+              onClick={locate}
+              className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+
+        {state.status === 'fallback' && <LocationFallback onRetry={locate} />}
+
+        {state.status === 'ready' &&
+          (state.places.length === 0 ? (
+            // Reached only after the widest radius came back empty — the user may
+            // have places, just none within range (e.g. traveling). Offer both
+            // "check in" and the full history so this never reads as "you have
+            // nothing."
+            <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-lg shadow px-6">
+              <p className="text-gray-600 dark:text-gray-400 mb-6">
+                No places within 50&nbsp;km. Your spots may just be further
+                afield.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                <a
+                  href="/check-in"
+                  className="inline-flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+                >
+                  Check in somewhere
+                </a>
+                <a
+                  href="/history"
+                  className="inline-flex items-center justify-center py-2 px-4 rounded-lg font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                >
+                  View all your places
+                </a>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {state.places.map(place => (
+                <a
+                  key={place.id}
+                  href={`/places/${place.id}`}
+                  className="block bg-white dark:bg-gray-800 rounded-lg shadow p-5 hover:shadow-md transition-shadow"
+                >
+                  <div className="flex justify-between items-start gap-4">
+                    <div className="min-w-0">
+                      <h2 className="text-xl font-semibold text-gray-900 dark:text-white truncate">
+                        {place.name}
+                      </h2>
+                      {place.formattedAddress && (
+                        <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                          {place.formattedAddress}
+                        </p>
+                      )}
+                      {place.topDish && (
+                        <div className="mt-2 flex items-center gap-2 flex-wrap">
+                          <span className="text-gray-700 dark:text-gray-300">
+                            {place.topDish}
+                          </span>
+                          {place.topVerdict && (
+                            <VerdictBadge verdict={place.topVerdict} />
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <span className="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      {formatDistance(place.distanceMeters)}
+                    </span>
+                  </div>
+                </a>
+              ))}
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+// Graceful degrade when we can't use location: explain, offer a retry, and keep
+// the app usable via full history (backlog-specified fallback).
+function LocationFallback({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-lg shadow px-6">
+      <div className="text-3xl mb-3">📍</div>
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+        Turn on location to see places near you
+      </h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-6 max-w-md mx-auto">
+        Allow location access and we&apos;ll sort your places by distance so you
+        can spot the good one nearby. Until then, everything&apos;s in your
+        history.
+      </p>
+      <div className="flex flex-col sm:flex-row gap-3 justify-center">
+        <button
+          onClick={onRetry}
+          className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+        >
+          Enable location
+        </button>
+        <a
+          href="/history"
+          className="inline-flex items-center justify-center py-2 px-4 rounded-lg font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        >
+          View your history
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -7,8 +7,22 @@ import {
   primaryKey,
   doublePrecision,
   varchar,
+  customType,
+  index,
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { VERDICTS } from '@/lib/verdict';
+
+// PostGIS geography point (S6). Drizzle has no native geography type, so this is
+// a thin custom type: the DB stores/queries it as geography(Point,4326); the app
+// never reads it as a value (near-me queries reference it via raw `sql`
+// fragments — ST_DWithin/ST_Distance), so the driver representation is opaque
+// WKB we just pass through.
+const geographyPoint = customType<{ data: string; driverData: string }>({
+  dataType() {
+    return 'geography(Point, 4326)';
+  },
+});
 
 // "Would you order this again?" — the heart of the product (S2).
 // Nullable on the table: historic rows predate the verdict; the form
@@ -75,23 +89,36 @@ export const verificationTokens = pgTable(
 // Google ID is a unique lookup key. Address/type are nullable: rows backfilled
 // from legacy check-ins never captured them, and Google details are
 // contractually cacheable only ~30 days, so treat them as refreshable.
-export const places = pgTable('places', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  googlePlaceId: text('google_place_id').notNull().unique(),
-  name: text('name').notNull(),
-  formattedAddress: text('formatted_address'),
-  primaryType: text('primary_type'),
-  lat: doublePrecision('lat').notNull(),
-  lng: doublePrecision('lng').notNull(),
-  createdAt: timestamp('created_at', { mode: 'date', withTimezone: true })
-    .defaultNow()
-    .notNull(),
-  updatedAt: timestamp('updated_at', { mode: 'date', withTimezone: true })
-    .defaultNow()
-    .notNull(),
-});
+export const places = pgTable(
+  'places',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    googlePlaceId: text('google_place_id').notNull().unique(),
+    name: text('name').notNull(),
+    formattedAddress: text('formatted_address'),
+    primaryType: text('primary_type'),
+    lat: doublePrecision('lat').notNull(),
+    lng: doublePrecision('lng').notNull(),
+    // Spatial mirror of lat/lng (S6). GENERATED STORED so the DB derives it from
+    // the scalars — lat/lng stay the source of truth and the point can never
+    // drift; no write site sets it. Note the longitude-first argument order.
+    // Backs the GiST index below for fast "near me" (ST_DWithin) queries.
+    location: geographyPoint('location').generatedAlwaysAs(
+      sql`ST_MakePoint("lng", "lat")::geography`
+    ),
+    createdAt: timestamp('created_at', { mode: 'date', withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { mode: 'date', withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  table => ({
+    locationIdx: index('places_location_idx').using('gist', table.location),
+  })
+);
 
 export const checkIns = pgTable('check_ins', {
   id: text('id')

--- a/src/lib/places/near-me.test.ts
+++ b/src/lib/places/near-me.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// findPlacesNearUser imports the db client (which throws without DATABASE_URL);
+// mock it. The tests below stub the query builder to cover the control flow
+// (radius-widening ladder, empty short-circuit, per-place visit bucketing) — the
+// actual PostGIS SQL (ST_DWithin/ST_Distance/GiST) is exercised against a real
+// DB in the S6 verification step, not here.
+vi.mock('@/lib/db/client', () => ({ db: { select: vi.fn() } }));
+
+import {
+  summarizeTopDish,
+  findPlacesNearUser,
+  RADIUS_LADDER_METERS,
+} from './near-me';
+import { db } from '@/lib/db/client';
+import type { DishVisit } from '@/lib/dishes/rollup';
+
+// A stubbed drizzle query builder: chainable and awaitable, resolving to `result`
+// whether the caller ends the chain at `.orderBy()` (the places query) or awaits
+// after `.where()` (the visits query).
+function stubQuery(result: unknown) {
+  const q: Record<string, unknown> = {
+    from: () => q,
+    where: () => q,
+    orderBy: () => Promise.resolve(result),
+    then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(onF, onR),
+  };
+  return q;
+}
+
+function visit(
+  dishText: string,
+  verdict: DishVisit['verdict'],
+  daysAgo: number
+): DishVisit {
+  return {
+    dishText,
+    verdict,
+    visitDatetime: new Date(Date.now() - daysAgo * 86_400_000),
+  };
+}
+
+describe('summarizeTopDish', () => {
+  it('returns nulls for a place with no visits', () => {
+    expect(summarizeTopDish([])).toEqual({ topDish: null, topVerdict: null });
+  });
+
+  it('picks the most-ordered dish as the top dish', () => {
+    const visits = [
+      visit('Burger', 'yes', 30),
+      visit('Burger', 'yes', 10),
+      visit('Salad', 'no', 5),
+    ];
+    expect(summarizeTopDish(visits).topDish).toBe('Burger');
+  });
+
+  it('uses the latest verdict for the top dish, not the oldest', () => {
+    const visits = [
+      visit('Burger', 'yes', 30),
+      visit('Burger', 'no', 2), // most recent — verdict changed to no
+      visit('Burger', 'yes', 15),
+    ];
+    expect(summarizeTopDish(visits)).toEqual({
+      topDish: 'Burger',
+      topVerdict: 'no',
+    });
+  });
+
+  it('groups casing/whitespace variants together via the S5 rollup', () => {
+    const visits = [
+      visit('Club Sandwich', 'yes', 20),
+      visit('club sandwich ', 'maybe', 4),
+      visit('Fries', 'yes', 8),
+    ];
+    // Three raw rows but "Club Sandwich" wins with 2 grouped visits.
+    expect(summarizeTopDish(visits).topDish).toBe('club sandwich ');
+  });
+
+  it('surfaces a null verdict (legacy visit) without crashing', () => {
+    expect(summarizeTopDish([visit('Toast', null, 1)])).toEqual({
+      topDish: 'Toast',
+      topVerdict: null,
+    });
+  });
+});
+
+describe('RADIUS_LADDER_METERS', () => {
+  it('is strictly widening, starting local (~2km)', () => {
+    expect(RADIUS_LADDER_METERS[0]).toBe(2000);
+    for (let i = 1; i < RADIUS_LADDER_METERS.length; i++) {
+      expect(RADIUS_LADDER_METERS[i]).toBeGreaterThan(
+        RADIUS_LADDER_METERS[i - 1]
+      );
+    }
+  });
+});
+
+describe('findPlacesNearUser (control flow, db stubbed)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns [] and never queries visits when all radii are empty', async () => {
+    (db.select as Mock).mockReturnValue(stubQuery([]));
+
+    const result = await findPlacesNearUser({
+      userId: 'u1',
+      lat: 37.77,
+      lng: -122.42,
+    });
+
+    expect(result).toEqual([]);
+    // One select per radius rung, and no visits query (short-circuited).
+    expect((db.select as Mock).mock.calls).toHaveLength(
+      RADIUS_LADDER_METERS.length
+    );
+  });
+
+  it('stops widening at the first radius that returns places', async () => {
+    const placeRow = {
+      id: 'p1',
+      name: 'Tartine',
+      formattedAddress: '600 Guerrero St',
+      distanceMeters: '42.4', // string, as the driver may return it
+    };
+    (db.select as Mock)
+      .mockReturnValueOnce(stubQuery([])) // 2km: empty
+      .mockReturnValueOnce(stubQuery([placeRow])) // 10km: hit — stop here
+      .mockReturnValueOnce(
+        stubQuery([
+          {
+            placeUuid: 'p1',
+            dishText: 'Morning bun',
+            verdict: 'yes',
+            visitDatetime: new Date(),
+          },
+        ])
+      ); // visits
+
+    const result = await findPlacesNearUser({
+      userId: 'u1',
+      lat: 37.77,
+      lng: -122.42,
+    });
+
+    // 2 place queries (empty, then hit) + 1 visits query = 3, NOT the full ladder.
+    expect((db.select as Mock).mock.calls).toHaveLength(3);
+    expect(result).toEqual([
+      {
+        id: 'p1',
+        name: 'Tartine',
+        formattedAddress: '600 Guerrero St',
+        distanceMeters: 42, // Number()-coerced and rounded
+        topDish: 'Morning bun',
+        topVerdict: 'yes',
+      },
+    ]);
+  });
+
+  it('buckets visits to the right place for the top-dish summary', async () => {
+    const places = [
+      { id: 'p1', name: 'A', formattedAddress: null, distanceMeters: 10 },
+      { id: 'p2', name: 'B', formattedAddress: null, distanceMeters: 20 },
+    ];
+    const visits = [
+      {
+        placeUuid: 'p1',
+        dishText: 'Burger',
+        verdict: 'yes',
+        visitDatetime: new Date(Date.now() - 1000),
+      },
+      {
+        placeUuid: 'p1',
+        dishText: 'Burger',
+        verdict: 'no',
+        visitDatetime: new Date(),
+      },
+      {
+        placeUuid: 'p2',
+        dishText: 'Salad',
+        verdict: 'maybe',
+        visitDatetime: new Date(),
+      },
+    ];
+    (db.select as Mock)
+      .mockReturnValueOnce(stubQuery(places)) // 2km hit
+      .mockReturnValueOnce(stubQuery(visits));
+
+    const result = await findPlacesNearUser({
+      userId: 'u1',
+      lat: 0,
+      lng: 0,
+    });
+
+    expect(result.map(p => [p.id, p.topDish, p.topVerdict])).toEqual([
+      ['p1', 'Burger', 'no'], // latest verdict wins
+      ['p2', 'Salad', 'maybe'],
+    ]);
+  });
+});

--- a/src/lib/places/near-me.ts
+++ b/src/lib/places/near-me.ts
@@ -1,0 +1,136 @@
+// "Near me" spatial query (S6): the user's own places, nearest-first, each with
+// its top dish and verdict — the data behind the home screen. Factored as a lib
+// because S7 (map) reuses it with a bounding-box variant.
+//
+// Distance/containment run in Postgres via PostGIS: ST_DWithin (index-backed by
+// the GiST index on places.location) filters to a radius, ST_Distance orders.
+// The dish rollup stays in JS — it reuses the S5 read-time grouping so "top
+// dish" means exactly what it does on the place page.
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '@/lib/db/client';
+import { checkIns, places } from '@/lib/db/schema';
+import { rollupDishes, type DishVisit } from '@/lib/dishes/rollup';
+import type { Verdict } from '@/lib/verdict';
+
+export interface NearbyPlace {
+  id: string;
+  name: string;
+  formattedAddress: string | null;
+  /** Great-circle distance from the user, in whole meters. */
+  distanceMeters: number;
+  /** The user's usual here (most-ordered dish); null if somehow no visits. */
+  topDish: string | null;
+  /** That dish's latest verdict; null for legacy visits without one. */
+  topVerdict: Verdict | null;
+}
+
+// Widen the search if the smaller radius is empty, so someone whose places are
+// across town — or who's traveling — still sees their history instead of a void.
+// Meters. Stops at the first radius that returns anything.
+export const RADIUS_LADDER_METERS = [2000, 10000, 50000] as const;
+
+/**
+ * Reduce a place's visits to its headline dish + verdict using the S5 rollup:
+ * the most-ordered dish wins, and its latest verdict is shown. Pure — unit
+ * tested without a database.
+ */
+export function summarizeTopDish(visits: readonly DishVisit[]): {
+  topDish: string | null;
+  topVerdict: Verdict | null;
+} {
+  const top = rollupDishes(visits)[0];
+  return {
+    topDish: top?.displayName ?? null,
+    topVerdict: top?.latestVerdict ?? null,
+  };
+}
+
+/**
+ * Places the signed-in user has checked into near a point, nearest-first, each
+ * summarized with its top dish/verdict. Empty array if the user has no places
+ * within the widest radius.
+ */
+export async function findPlacesNearUser({
+  userId,
+  lat,
+  lng,
+}: {
+  userId: string;
+  lat: number;
+  lng: number;
+}): Promise<NearbyPlace[]> {
+  // Longitude-first — the standard PostGIS gotcha.
+  const point = sql`ST_MakePoint(${lng}, ${lat})::geography`;
+  const distance = sql<number>`ST_Distance(${places.location}, ${point})`;
+
+  // Only the user's own places count. EXISTS keeps this to one row per place
+  // (vs. a join that would multiply by visit count) and lets the planner use
+  // the GiST index for the ST_DWithin bound.
+  const ownedByUser = sql`EXISTS (
+    SELECT 1 FROM ${checkIns}
+    WHERE ${checkIns.placeUuid} = ${places.id}
+      AND ${checkIns.userId} = ${userId}
+  )`;
+
+  let rows: {
+    id: string;
+    name: string;
+    formattedAddress: string | null;
+    distanceMeters: number;
+  }[] = [];
+
+  for (const radius of RADIUS_LADDER_METERS) {
+    rows = await db
+      .select({
+        id: places.id,
+        name: places.name,
+        formattedAddress: places.formattedAddress,
+        distanceMeters: distance,
+      })
+      .from(places)
+      .where(
+        and(
+          sql`ST_DWithin(${places.location}, ${point}, ${radius})`,
+          ownedByUser
+        )
+      )
+      // Tiebreaker keeps ordering stable across refreshes when two places sit
+      // at the same distance (or tie after float rounding).
+      .orderBy(distance, places.id);
+    if (rows.length > 0) break;
+  }
+
+  if (rows.length === 0) return [];
+
+  // Batch-fetch the user's visits for the returned places, then roll up per
+  // place in JS. One extra query total (not one per place).
+  const placeIds = rows.map(r => r.id);
+  const visits = await db
+    .select({
+      placeUuid: checkIns.placeUuid,
+      dishText: checkIns.dishText,
+      verdict: checkIns.verdict,
+      visitDatetime: checkIns.visitDatetime,
+    })
+    .from(checkIns)
+    .where(
+      and(eq(checkIns.userId, userId), inArray(checkIns.placeUuid, placeIds))
+    );
+
+  const visitsByPlace = new Map<string, DishVisit[]>();
+  for (const v of visits) {
+    if (!v.placeUuid) continue;
+    const bucket = visitsByPlace.get(v.placeUuid);
+    if (bucket) bucket.push(v);
+    else visitsByPlace.set(v.placeUuid, [v]);
+  }
+
+  return rows.map(row => ({
+    id: row.id,
+    name: row.name,
+    formattedAddress: row.formattedAddress,
+    // ST_Distance can arrive as a string over the wire; coerce before rounding.
+    distanceMeters: Math.round(Number(row.distanceMeters)),
+    ...summarizeTopDish(visitsByPlace.get(row.id) ?? []),
+  }));
+}


### PR DESCRIPTION
## What & why

S6 from `BACKLOG.md` — the marquee feature. Signed-in users now land on **"Near you"**: their places sorted by distance from current location, each with its top dish and verdict, instead of a bare redirect to `/history`. First screen that answers the product's core question — _"I'm near here, what did I get and was it good?"_ — without navigating to a specific place.

## Changes

- **`places.location`**: generated `STORED` `geography(Point,4326)` derived from `lat`/`lng`, GiST-indexed (migration `0006`). The DB maintains it, so it can't drift from the scalars and no write site sets it — scalars stay the source of truth. Migration hand-authored for `CREATE EXTENSION postgis` + the generated column (drizzle-kit can't emit those).
- **`findPlacesNearUser`** (`src/lib/places/near-me.ts`): index-backed `ST_DWithin` radius filter + `ST_Distance` ordering, a 2/10/50km widening ladder, reusing the S5 dish rollup for each place's top dish. Factored as a lib so S7 (map) can reuse it with a bounding-box variant.
- **`GET /api/places/near-me?lat=&lng=`**: auth-gated, coordinate-validated.
- **`NearMeHome`** client component: geolocation → fetch → distance-ordered cards, with graceful denied/unavailable/timeout fallback to history.
- **Navbar**: Home / Check in / History links.

## Verification

- Static gates green locally: `tsc`, lint, prettier, **148 tests**, `build`.
- Reviewer pass (adversarial) applied: empty-state history fallback, geolocation timeout, deterministic sort tiebreaker, real `findPlacesNearUser` control-flow tests.
- ⚠️ **Live spatial SQL / GiST index / app flow NOT yet verified** — no dev DB (neon-http needs a Neon branch). Since `migrate-on-deploy` is production-only, the near-me home page will error on a *preview* (reads `places.location`, which only lands on the production migration). Plan: verify on the **production deploy after merge** — migration `0006` runs before the new code serves (expand-only, self-consistent). Confirm the build log shows `0006` applied, then load the home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)