### PR TITLE
Add a map view of your places

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "bcrypt": "^6.0.0",
     "drizzle-orm": "^0.44.7",
+    "maplibre-gl": "^5.24.0",
     "next": "15.5.15",
     "next-auth": "^5.0.0-beta.30",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       drizzle-orm:
         specifier: ^0.44.7
         version: 0.44.7(@neondatabase/serverless@1.0.2)(@types/pg@8.15.6)(pg@8.16.3)
+      maplibre-gl:
+        specifier: ^5.24.0
+        version: 5.24.0
       next:
         specifier: 15.5.15
         version: 15.5.15(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -819,6 +822,42 @@ packages:
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
+  '@mapbox/jsonlint-lines-primitives@2.0.3':
+    resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
+    engines: {node: '>= 22'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
+
+  '@mapbox/vector-tile@2.0.5':
+    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@6.1.1':
+    resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.12':
+    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
+
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
 
@@ -1173,6 +1212,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1798,6 +1840,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
   electron-to-chromium@1.5.259:
     resolution: {integrity: sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ==}
 
@@ -2096,6 +2141,9 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2355,6 +2403,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -2367,6 +2418,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2491,6 +2545,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  maplibre-gl@5.24.0:
+    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2543,6 +2601,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nano-spawn@1.0.2:
     resolution: {integrity: sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==}
@@ -2685,6 +2746,14 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@4.0.2:
+    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
+    hasBin: true
+
+  pbf@5.1.2:
+    resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
+    hasBin: true
+
   pg-cloudflare@1.2.7:
     resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
 
@@ -2763,6 +2832,9 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   preact-render-to-string@6.5.11:
     resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
     peerDependencies:
@@ -2787,12 +2859,18 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
@@ -2835,6 +2913,9 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
 
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
@@ -3079,6 +3160,9 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
@@ -3894,6 +3978,47 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  '@mapbox/jsonlint-lines-primitives@2.0.3': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
+
+  '@mapbox/vector-tile@2.0.5':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.2
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@6.1.1':
+    dependencies:
+      kdbush: 4.1.0
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.12':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
+
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
       '@emnapi/core': 1.4.3
@@ -4178,6 +4303,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -4743,6 +4870,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  earcut@3.2.3: {}
+
   electron-to-chromium@1.5.259: {}
 
   emoji-regex@10.4.0: {}
@@ -5235,6 +5364,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gl-matrix@3.4.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -5498,6 +5629,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -5510,6 +5643,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -5631,6 +5766,28 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  maplibre-gl@5.24.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.5
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.1
+      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/mlt': 1.1.12
+      '@maplibre/vt-pbf': 4.3.2
+      '@types/geojson': 7946.0.16
+      earcut: 3.2.3
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      murmurhash-js: 1.0.0
+      pbf: 4.0.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.12.2: {}
@@ -5667,6 +5824,8 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  murmurhash-js@1.0.0: {}
 
   nano-spawn@1.0.2: {}
 
@@ -5798,6 +5957,14 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@4.0.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
+  pbf@5.1.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   pg-cloudflare@1.2.7:
     optional: true
 
@@ -5865,6 +6032,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  potpack@2.1.0: {}
+
   preact-render-to-string@6.5.11(preact@10.24.3):
     dependencies:
       preact: 10.24.3
@@ -5887,9 +6056,13 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protocol-buffers-schema@3.6.1: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  quickselect@3.0.0: {}
 
   react-dom@19.1.0(react@19.1.0):
     dependencies:
@@ -5934,6 +6107,10 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
 
   resolve@1.22.10:
     dependencies:
@@ -6258,6 +6435,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@3.0.3: {}
 

--- a/src/app/api/places/in-bounds/route.test.ts
+++ b/src/app/api/places/in-bounds/route.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }));
+vi.mock('@/lib/places/near-me', () => ({ findPlacesInBounds: vi.fn() }));
+
+import { GET } from './route';
+import { auth } from '@/auth';
+import { findPlacesInBounds } from '@/lib/places/near-me';
+
+const authed = () =>
+  (auth as Mock).mockResolvedValue({
+    user: { id: 'user-123', email: 'test@example.com' },
+    expires: '',
+  });
+
+function req(query: string) {
+  return new NextRequest(`http://localhost/api/places/in-bounds${query}`);
+}
+
+const validBounds = '?minLat=37.7&minLng=-122.5&maxLat=37.8&maxLng=-122.4';
+
+describe('GET /api/places/in-bounds', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects unauthenticated requests', async () => {
+    (auth as Mock).mockResolvedValue(null);
+    const res = await GET(req(validBounds));
+    expect(res.status).toBe(401);
+    expect(findPlacesInBounds).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing bounds', async () => {
+    authed();
+    const res = await GET(req(''));
+    expect(res.status).toBe(400);
+    expect(findPlacesInBounds).not.toHaveBeenCalled();
+  });
+
+  it('rejects out-of-range latitude', async () => {
+    authed();
+    const res = await GET(
+      req('?minLat=-91&minLng=-122.5&maxLat=37.8&maxLng=-122.4')
+    );
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.error).toContain('Lat');
+  });
+
+  it('rejects inverted bounds (min > max)', async () => {
+    authed();
+    const res = await GET(
+      req('?minLat=37.8&minLng=-122.5&maxLat=37.7&maxLng=-122.4')
+    );
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.error).toContain('Lat');
+  });
+
+  it('returns places within the viewport for valid bounds', async () => {
+    authed();
+    const places = [
+      {
+        id: 'p1',
+        name: 'Blue Bottle',
+        formattedAddress: '66 Mint St',
+        lat: 37.78,
+        lng: -122.42,
+        topDish: 'Cappuccino',
+        topVerdict: 'yes',
+      },
+    ];
+    (findPlacesInBounds as Mock).mockResolvedValue(places);
+
+    const res = await GET(req(validBounds));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.places).toEqual(places);
+    expect(findPlacesInBounds).toHaveBeenCalledWith({
+      userId: 'user-123',
+      bounds: { minLat: 37.7, minLng: -122.5, maxLat: 37.8, maxLng: -122.4 },
+    });
+  });
+
+  it('requests all places (no bounds) when all=1', async () => {
+    authed();
+    (findPlacesInBounds as Mock).mockResolvedValue([]);
+
+    const res = await GET(req('?all=1'));
+
+    expect(res.status).toBe(200);
+    expect(findPlacesInBounds).toHaveBeenCalledWith({
+      userId: 'user-123',
+      bounds: null,
+    });
+  });
+
+  it('surfaces query failures as 500', async () => {
+    authed();
+    (findPlacesInBounds as Mock).mockRejectedValue(new Error('PostGIS down'));
+    const res = await GET(req(validBounds));
+    const data = await res.json();
+    expect(res.status).toBe(500);
+    expect(data.error).toBe('PostGIS down');
+  });
+});

--- a/src/app/api/places/in-bounds/route.ts
+++ b/src/app/api/places/in-bounds/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { findPlacesInBounds } from '@/lib/places/near-me';
+
+// GET /api/places/in-bounds?minLat=&minLng=&maxLat=&maxLng= — the signed-in
+// user's places inside a map viewport, each with its top dish and verdict.
+// Backs the map view; the bounds come from MapLibre's getBounds() on every pan/
+// zoom, hence a query-param GET.
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+
+  // `all=1` asks for every place (map opens framed to everywhere you've been);
+  // otherwise a viewport is required and validated below.
+  const wantsAll = searchParams.get('all') === '1';
+
+  // Parse explicitly: Number(null)/Number('')/Number('  ') all coerce to 0 (a
+  // valid coord), so a missing/blank param would silently read as 0 — trim then
+  // reject up front.
+  const parse = (name: string) => {
+    const raw = searchParams.get(name)?.trim();
+    return raw ? Number(raw) : NaN;
+  };
+
+  let bounds: {
+    minLat: number;
+    minLng: number;
+    maxLat: number;
+    maxLng: number;
+  } | null = null;
+
+  if (!wantsAll) {
+    const minLat = parse('minLat');
+    const maxLat = parse('maxLat');
+    const minLng = parse('minLng');
+    const maxLng = parse('maxLng');
+
+    const latOk = (v: number) => Number.isFinite(v) && v >= -90 && v <= 90;
+    const lngOk = (v: number) => Number.isFinite(v) && v >= -180 && v <= 180;
+
+    if (!latOk(minLat) || !latOk(maxLat) || minLat > maxLat) {
+      return NextResponse.json(
+        { error: 'minLat/maxLat are required, between -90 and 90, min ≤ max' },
+        { status: 400 }
+      );
+    }
+    if (!lngOk(minLng) || !lngOk(maxLng) || minLng > maxLng) {
+      return NextResponse.json(
+        {
+          error: 'minLng/maxLng are required, between -180 and 180, min ≤ max',
+        },
+        { status: 400 }
+      );
+    }
+    bounds = { minLat, minLng, maxLat, maxLng };
+  }
+
+  try {
+    const places = await findPlacesInBounds({
+      userId: session.user.id,
+      bounds,
+    });
+    return NextResponse.json({ places }, { status: 200 });
+  } catch (error) {
+    console.error('Error fetching places in bounds:', error);
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/near-me-home.test.tsx
+++ b/src/components/near-me-home.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NearMeHome } from './near-me-home';
+
+// PlacesMap pulls in MapLibre (WebGL, no jsdom support), so stub it — these
+// tests exercise the toggle wiring, not the map itself.
+vi.mock('@/components/places-map', () => ({
+  PlacesMap: () => <div data-testid="places-map">map</div>,
+}));
 
 // NearMeHome owns the geolocation → fetch flow. These tests cover the graceful
 // paths (unavailable / denied / success) without a real browser or DB.
@@ -104,5 +111,31 @@ describe('NearMeHome', () => {
     expect(
       screen.getByRole('link', { name: 'View all your places' })
     ).toHaveAttribute('href', '/history');
+  });
+
+  it('switches to the map view — and back — via the toggle', async () => {
+    const user = userEvent.setup();
+    // Map view must work regardless of geolocation, so leave it unavailable.
+    render(<NearMeHome />);
+
+    // Defaults to the list: the location fallback shows, no map.
+    expect(
+      await screen.findByText('Turn on location to see places near you')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('places-map')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Map' }));
+
+    // Map appears; the list's location fallback is gone.
+    expect(await screen.findByTestId('places-map')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Turn on location to see places near you')
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'List' }));
+    expect(screen.queryByTestId('places-map')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Turn on location to see places near you')
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/near-me-home.tsx
+++ b/src/components/near-me-home.tsx
@@ -1,9 +1,24 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { VerdictBadge } from '@/components/verdict-badge';
 import { formatDistance } from '@/lib/places/distance';
 import type { Verdict } from '@/lib/verdict';
+
+// MapLibre touches window/WebGL, so the map is client-only — never server-render
+// it. Loaded lazily so its weight lands only when the user opens the map view.
+const PlacesMap = dynamic(
+  () => import('@/components/places-map').then(m => m.PlacesMap),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[70vh] w-full rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
+    ),
+  }
+);
+
+type View = 'list' | 'map';
 
 interface NearbyPlace {
   id: string;
@@ -27,6 +42,11 @@ type State =
 // unavailable or denied (never a dead screen).
 export function NearMeHome() {
   const [state, setState] = useState<State>({ status: 'locating' });
+  const [view, setView] = useState<View>('list');
+  // Remembered so the map can open centered on the user when we have a fix.
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(
+    null
+  );
 
   const locate = useCallback(() => {
     if (typeof navigator === 'undefined' || !navigator.geolocation) {
@@ -40,6 +60,7 @@ export function NearMeHome() {
         setState({ status: 'loading' });
         try {
           const { latitude, longitude } = position.coords;
+          setCoords({ lat: latitude, lng: longitude });
           const res = await fetch(
             `/api/places/near-me?lat=${latitude}&lng=${longitude}`
           );
@@ -85,26 +106,35 @@ export function NearMeHome() {
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
             Near you
           </h1>
-          <a
-            href="/check-in"
-            className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors whitespace-nowrap"
-          >
-            New Check-In
-          </a>
+          <div className="flex items-center gap-3">
+            <ViewToggle view={view} onChange={setView} />
+            <a
+              href="/check-in"
+              className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors whitespace-nowrap"
+            >
+              New Check-In
+            </a>
+          </div>
         </div>
 
-        {(state.status === 'locating' || state.status === 'loading') && (
-          <div className="text-center py-12">
-            <div className="animate-spin h-12 w-12 border-4 border-blue-600 border-t-transparent rounded-full mx-auto"></div>
-            <p className="mt-4 text-gray-600 dark:text-gray-400">
-              {state.status === 'locating'
-                ? 'Finding your location…'
-                : 'Looking for your places nearby…'}
-            </p>
-          </div>
-        )}
+        {/* Map view stands alone: it frames all your places by viewport, so it
+            works even when the list's geolocation was denied or is still
+            resolving. */}
+        {view === 'map' && <PlacesMap center={coords ?? undefined} />}
 
-        {state.status === 'error' && (
+        {view === 'list' &&
+          (state.status === 'locating' || state.status === 'loading') && (
+            <div className="text-center py-12">
+              <div className="animate-spin h-12 w-12 border-4 border-blue-600 border-t-transparent rounded-full mx-auto"></div>
+              <p className="mt-4 text-gray-600 dark:text-gray-400">
+                {state.status === 'locating'
+                  ? 'Finding your location…'
+                  : 'Looking for your places nearby…'}
+              </p>
+            </div>
+          )}
+
+        {view === 'list' && state.status === 'error' && (
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
             <p className="text-red-600 dark:text-red-400 mb-4">
               {state.message}
@@ -118,9 +148,12 @@ export function NearMeHome() {
           </div>
         )}
 
-        {state.status === 'fallback' && <LocationFallback onRetry={locate} />}
+        {view === 'list' && state.status === 'fallback' && (
+          <LocationFallback onRetry={locate} />
+        )}
 
-        {state.status === 'ready' &&
+        {view === 'list' &&
+          state.status === 'ready' &&
           (state.places.length === 0 ? (
             // Reached only after the widest radius came back empty — the user may
             // have places, just none within range (e.g. traveling). Offer both
@@ -184,6 +217,42 @@ export function NearMeHome() {
             </div>
           ))}
       </div>
+    </div>
+  );
+}
+
+// Segmented List / Map switch for the home screen. The two views share the same
+// places; the map just plots what the list ranks.
+function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: View;
+  onChange: (view: View) => void;
+}) {
+  const base =
+    'px-3 py-1.5 text-sm font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500';
+  const active =
+    'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm';
+  const inactive =
+    'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white';
+  return (
+    <div
+      role="group"
+      aria-label="Choose list or map view"
+      className="inline-flex gap-1 p-1 bg-gray-200 dark:bg-gray-800 rounded-lg"
+    >
+      {(['list', 'map'] as const).map(v => (
+        <button
+          key={v}
+          type="button"
+          aria-pressed={view === v}
+          onClick={() => onChange(v)}
+          className={`${base} ${view === v ? active : inactive}`}
+        >
+          {v === 'list' ? 'List' : 'Map'}
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/components/places-map.tsx
+++ b/src/components/places-map.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { verdictStyles, type Verdict } from '@/lib/verdict';
+// Type-only — erased at compile time, so importing from the server-side lib
+// doesn't pull Drizzle/db into this client bundle. Keeps the shape in one place.
+import type { MapPlace } from '@/lib/places/near-me';
+
+// Free, keyless vector tiles — no Google Maps SDK, no token-metered vendor lock.
+const TILE_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
+
+// Pin color = the verdict of the place's top dish, so the map reads at a glance:
+// green = order again, amber = on the fence, red = skip, gray = no verdict yet.
+const VERDICT_PIN_COLOR: Record<Verdict, string> = {
+  yes: '#16a34a', // green-600
+  maybe: '#f59e0b', // amber-500
+  no: '#dc2626', // red-600
+};
+const NO_VERDICT_PIN_COLOR = '#6b7280'; // gray-500
+
+function pinColor(verdict: Verdict | null): string {
+  return verdict ? VERDICT_PIN_COLOR[verdict] : NO_VERDICT_PIN_COLOR;
+}
+
+// Popup content is built as an HTML string, so anything place-derived (name,
+// dish) must be escaped — these come from Google/user input, not our control.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function popupHtml(place: MapPlace): string {
+  const name = escapeHtml(place.name);
+  const dishLine = place.topDish
+    ? `<div style="margin-top:2px">${escapeHtml(place.topDish)}${
+        place.topVerdict
+          ? ` · <strong>${escapeHtml(verdictStyles[place.topVerdict].label)}</strong>`
+          : ''
+      }</div>`
+    : '';
+  return `<div style="font:14px system-ui,sans-serif;line-height:1.35">
+    <div style="font-weight:600">${name}</div>
+    ${dishLine}
+    <a href="/places/${encodeURIComponent(place.id)}" style="display:inline-block;margin-top:6px;color:#2563eb;font-weight:500">View place →</a>
+  </div>`;
+}
+
+interface PlacesMapProps {
+  /** Where to center initially — the user's location when we have it. */
+  center?: { lat: number; lng: number };
+}
+
+// The map view of everywhere you've been: one pin per place, colored by the
+// verdict of your top dish there, tap for a popup linking to the place page.
+// Client-only (MapLibre touches window/WebGL) — imported with ssr:false. Fetches
+// by viewport on every pan/zoom so it scales past a single page of places.
+export function PlacesMap({ center }: PlacesMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const markersRef = useRef<maplibregl.Marker[]>([]);
+  // center is initial-only: read once at mount so a later geolocation fix (or a
+  // retry producing a new coords object) doesn't tear down and rebuild the map,
+  // losing the user's pan/zoom. The `load` handler frames all places anyway.
+  const centerRef = useRef(center);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const initialCenter = centerRef.current;
+    const map = new maplibregl.Map({
+      container,
+      style: TILE_STYLE,
+      center: initialCenter
+        ? [initialCenter.lng, initialCenter.lat]
+        : [-98.5, 39.8], // US-ish fallback until we frame the user's places
+      zoom: initialCenter ? 12 : 3,
+      attributionControl: { compact: true },
+    });
+    map.addControl(new maplibregl.NavigationControl(), 'top-right');
+
+    let disposed = false;
+    let debounce: ReturnType<typeof setTimeout> | undefined;
+    // Monotonic request token: only the newest fetch may render, so a slow
+    // response from an earlier viewport can't overwrite pins for the current one.
+    let latestRequest = 0;
+
+    const render = (places: MapPlace[]) => {
+      markersRef.current.forEach(m => m.remove());
+      markersRef.current = places.map(place => {
+        const popup = new maplibregl.Popup({ offset: 24 }).setHTML(
+          popupHtml(place)
+        );
+        return new maplibregl.Marker({ color: pinColor(place.topVerdict) })
+          .setLngLat([place.lng, place.lat])
+          .setPopup(popup)
+          .addTo(map);
+      });
+    };
+
+    const fetchPlaces = async (query: string): Promise<MapPlace[]> => {
+      const res = await fetch(`/api/places/in-bounds?${query}`);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to load places');
+      }
+      const data = await res.json();
+      return data.places as MapPlace[];
+    };
+
+    // Build the query for the current viewport. MapLibre's getBounds() can
+    // return unwrapped/over-wide longitudes (panned past the antimeridian, or a
+    // zoomed-out wide screen); clamp to valid coords, and if the viewport spans
+    // the whole globe, ask for everything rather than an invalid box.
+    const viewportQuery = (): string => {
+      const b = map.getBounds();
+      const sw = b.getSouthWest();
+      const ne = b.getNorthEast();
+      if (ne.lng - sw.lng >= 360) return 'all=1';
+      const clampLat = (v: number) => Math.max(-90, Math.min(90, v));
+      const clampLng = (v: number) => Math.max(-180, Math.min(180, v));
+      return new URLSearchParams({
+        minLat: String(clampLat(sw.lat)),
+        maxLat: String(clampLat(ne.lat)),
+        minLng: String(clampLng(sw.lng)),
+        maxLng: String(clampLng(ne.lng)),
+      }).toString();
+    };
+
+    const load = async (query: string, onPlaces?: (p: MapPlace[]) => void) => {
+      const token = ++latestRequest;
+      try {
+        const places = await fetchPlaces(query);
+        if (disposed || token !== latestRequest) return;
+        setError(null);
+        onPlaces?.(places);
+        render(places);
+      } catch (err) {
+        if (disposed || token !== latestRequest) return;
+        setError(err instanceof Error ? err.message : 'Failed to load places');
+      }
+    };
+
+    const refresh = () => {
+      clearTimeout(debounce);
+      // Debounce so a pan/zoom gesture fires one request when it settles.
+      debounce = setTimeout(() => load(viewportQuery()), 250);
+    };
+
+    map.on('load', () => {
+      // Open framed to everywhere you've been (the whole point of the map), then
+      // let viewport fetches take over as the user explores. fitBounds emits a
+      // moveend that refetches the (now-framed) viewport — harmless, self-heals.
+      load('all=1', all => {
+        if (all.length === 0) return;
+        const b = new maplibregl.LngLatBounds();
+        all.forEach(p => b.extend([p.lng, p.lat]));
+        map.fitBounds(b, { padding: 64, maxZoom: 14, animate: false });
+      });
+    });
+
+    map.on('moveend', refresh);
+
+    return () => {
+      disposed = true;
+      clearTimeout(debounce);
+      markersRef.current.forEach(m => m.remove());
+      markersRef.current = [];
+      map.remove();
+    };
+  }, []);
+
+  return (
+    <div className="relative">
+      <div
+        ref={containerRef}
+        className="h-[70vh] w-full rounded-lg overflow-hidden shadow"
+        aria-label="Map of your places"
+      />
+      {error && (
+        <div className="absolute top-3 left-1/2 -translate-x-1/2 bg-red-50 dark:bg-red-900/40 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 text-sm rounded-lg px-4 py-2 shadow">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/places/near-me.ts
+++ b/src/lib/places/near-me.ts
@@ -1,27 +1,47 @@
-// "Near me" spatial query (S6): the user's own places, nearest-first, each with
-// its top dish and verdict — the data behind the home screen. Factored as a lib
-// because S7 (map) reuses it with a bounding-box variant.
+// Places-with-summary spatial queries: the user's own places, each with its top
+// dish and verdict — the data behind the home screen. Two shapes share one
+// rollup: "near me" (nearest-first within a radius, the list view) and "in
+// bounds" (everything in a map viewport, the map view).
 //
-// Distance/containment run in Postgres via PostGIS: ST_DWithin (index-backed by
-// the GiST index on places.location) filters to a radius, ST_Distance orders.
-// The dish rollup stays in JS — it reuses the S5 read-time grouping so "top
-// dish" means exactly what it does on the place page.
+// Distance/containment run in Postgres via PostGIS against the GiST index on
+// places.location: ST_DWithin filters to a radius, ST_Distance orders, and the
+// geography `&&` operator does index-backed bounding-box overlap for the map.
+// The dish rollup stays in JS — it reuses the read-time grouping so "top dish"
+// means exactly what it does on the place page.
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '@/lib/db/client';
 import { checkIns, places } from '@/lib/db/schema';
 import { rollupDishes, type DishVisit } from '@/lib/dishes/rollup';
 import type { Verdict } from '@/lib/verdict';
 
-export interface NearbyPlace {
+/** A place summarized by its headline dish + verdict — shared by both queries. */
+interface PlaceSummary {
+  topDish: string | null;
+  topVerdict: Verdict | null;
+}
+
+export interface NearbyPlace extends PlaceSummary {
   id: string;
   name: string;
   formattedAddress: string | null;
   /** Great-circle distance from the user, in whole meters. */
   distanceMeters: number;
-  /** The user's usual here (most-ordered dish); null if somehow no visits. */
-  topDish: string | null;
-  /** That dish's latest verdict; null for legacy visits without one. */
-  topVerdict: Verdict | null;
+}
+
+export interface MapPlace extends PlaceSummary {
+  id: string;
+  name: string;
+  formattedAddress: string | null;
+  lat: number;
+  lng: number;
+}
+
+/** A map viewport, as returned by MapLibre's `getBounds()`. */
+export interface Bounds {
+  minLat: number;
+  minLng: number;
+  maxLat: number;
+  maxLng: number;
 }
 
 // Widen the search if the smaller radius is empty, so someone whose places are
@@ -102,9 +122,91 @@ export async function findPlacesNearUser({
 
   if (rows.length === 0) return [];
 
-  // Batch-fetch the user's visits for the returned places, then roll up per
-  // place in JS. One extra query total (not one per place).
-  const placeIds = rows.map(r => r.id);
+  const summaries = await summarizePlaceVisits(
+    userId,
+    rows.map(r => r.id)
+  );
+
+  return rows.map(row => ({
+    id: row.id,
+    name: row.name,
+    formattedAddress: row.formattedAddress,
+    // ST_Distance can arrive as a string over the wire; coerce before rounding.
+    distanceMeters: Math.round(Number(row.distanceMeters)),
+    ...(summaries.get(row.id) ?? { topDish: null, topVerdict: null }),
+  }));
+}
+
+/**
+ * The signed-in user's places for the map, each summarized with its top
+ * dish/verdict. With `bounds`, only places inside that viewport; with `null`,
+ * all of them (the map opens framed to everywhere you've been, then narrows to
+ * the viewport as you explore). Unordered — the map places pins, it doesn't
+ * rank. Empty array if there are no matching places.
+ */
+export async function findPlacesInBounds({
+  userId,
+  bounds,
+}: {
+  userId: string;
+  bounds: Bounds | null;
+}): Promise<MapPlace[]> {
+  // Only the user's own places — same EXISTS pattern as near-me: one row per
+  // place, and it lets the planner use the GiST index for the && bound.
+  const ownedByUser = sql`EXISTS (
+    SELECT 1 FROM ${checkIns}
+    WHERE ${checkIns.placeUuid} = ${places.id}
+      AND ${checkIns.userId} = ${userId}
+  )`;
+
+  // Geography `&&` bounding-box overlap, index-backed by the GiST index on
+  // places.location. ST_MakeEnvelope wants (minLng, minLat, maxLng, maxLat) and
+  // returns geometry(4326); cast to geography so both sides match and the
+  // geography operator/index apply. Omitted for the "all places" case — a
+  // whole-globe envelope is degenerate in geography (its edges are great-circle
+  // arcs, and ±180° lng coincide), so "everything" must be no predicate, not a
+  // world-sized box.
+  const inViewport = bounds
+    ? sql`${places.location} && ST_MakeEnvelope(${bounds.minLng}, ${bounds.minLat}, ${bounds.maxLng}, ${bounds.maxLat}, 4326)::geography`
+    : undefined;
+
+  const rows = await db
+    .select({
+      id: places.id,
+      name: places.name,
+      formattedAddress: places.formattedAddress,
+      lat: places.lat,
+      lng: places.lng,
+    })
+    .from(places)
+    .where(inViewport ? and(inViewport, ownedByUser) : ownedByUser);
+
+  if (rows.length === 0) return [];
+
+  const summaries = await summarizePlaceVisits(
+    userId,
+    rows.map(r => r.id)
+  );
+
+  return rows.map(row => ({
+    id: row.id,
+    name: row.name,
+    formattedAddress: row.formattedAddress,
+    lat: row.lat,
+    lng: row.lng,
+    ...(summaries.get(row.id) ?? { topDish: null, topVerdict: null }),
+  }));
+}
+
+/**
+ * Batch-fetch the user's visits for a set of places and roll each place up to
+ * its top dish/verdict. One query total (not one per place); returns a map
+ * keyed by place id. Shared by both spatial queries.
+ */
+async function summarizePlaceVisits(
+  userId: string,
+  placeIds: string[]
+): Promise<Map<string, PlaceSummary>> {
   const visits = await db
     .select({
       placeUuid: checkIns.placeUuid,
@@ -125,12 +227,9 @@ export async function findPlacesNearUser({
     else visitsByPlace.set(v.placeUuid, [v]);
   }
 
-  return rows.map(row => ({
-    id: row.id,
-    name: row.name,
-    formattedAddress: row.formattedAddress,
-    // ST_Distance can arrive as a string over the wire; coerce before rounding.
-    distanceMeters: Math.round(Number(row.distanceMeters)),
-    ...summarizeTopDish(visitsByPlace.get(row.id) ?? []),
-  }));
+  const summaries = new Map<string, PlaceSummary>();
+  for (const id of placeIds) {
+    summaries.set(id, summarizeTopDish(visitsByPlace.get(id) ?? []));
+  }
+  return summaries;
 }


### PR DESCRIPTION
Adds a map view to the home screen, alongside the existing nearby list. A **List / Map** toggle switches between them.

## What you see

A map of everywhere you've been — one pin per place, **colored by the verdict of your top dish** there (green = order again, amber = on the fence, red = skip, gray = no verdict yet). Tap a pin for a popup with the place name, top dish, and verdict, linking to the place page. The map opens framed to all your places, then refetches by viewport as you pan and zoom.

## How it works

- **Data** — `findPlacesInBounds` runs a PostGIS bounding-box query (`location && ST_MakeEnvelope(...)::geography`, index-backed by the existing GiST index) and reuses the read-time dish rollup, so "top dish" means the same thing it does on place pages. `bounds: null` returns every place — a whole-globe envelope is degenerate in geography, so "everything" is *no* predicate rather than a world-sized box.
- **API** — `GET /api/places/in-bounds?minLat&minLng&maxLat&maxLng` (or `?all=1`), auth-gated, mirroring the near-me route's validation.
- **Map** — client-only MapLibre GL with keyless OpenFreeMap tiles (no Google Maps SDK, no token-metered vendor lock). Lazy-loaded via `dynamic(..., { ssr: false })`, so its weight lands only when the map view is opened (home route first-load JS unchanged at ~3.5 kB). Viewport refetch is debounced with request-token ordering so a slow response can't render stale pins; longitudes are clamped and globe-spanning viewports fall back to "all".

No schema change or migration — this reuses the existing `places.location` column and GiST index.

## Testing

- `tsc`, ESLint, and production build all clean.
- 156 unit tests pass, including new coverage for the in-bounds API (auth, validation, inverted bounds, `all=1`) and the List/Map toggle.
- ⚠️ No dev database locally (neon-http needs a Neon branch), so the PostGIS SQL and live map flow are statically reasoned, not run — verify against a preview/branch DB before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)